### PR TITLE
implement Deserialize for IntArray

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,10 @@ impl IntArray {
         let bpd = ELEMENT_BITS / b;
         (bpd, len.div_ceil(bpd))
     }
+    fn bits_for_max(max_val: Element) -> usize {
+        max_val.ffs().max(1)
+    }
+
     pub fn new(b: usize, len: usize) -> IntArray {
         let (bpd, cap) = IntArray::sizeval(b, len);
         debug!("bpd={}, cap={}", bpd, cap);
@@ -319,14 +323,7 @@ impl IntArray {
     }
 
     pub fn shape_auto(&self) -> IntArray {
-        if self.length == 0 {
-            return IntArray::new(1, 0);
-        }
-        let mv = self.iter().max().unwrap();
-        let bits = match mv.ffs() {
-            0 => 1,
-            n => n,
-        };
+        let bits = IntArray::bits_for_max(self.iter().max().unwrap_or(0));
         IntArray::new_with_iter(bits, self.iter())
     }
 
@@ -555,22 +552,22 @@ impl<'de> Visitor<'de> for IntArrayVisitor {
     where
         A: SeqAccess<'de>,
     {
-        let mut vals: Vec<Element> = Vec::new();
+        let hint = seq.size_hint().unwrap_or(0);
+        let mut vals: Vec<Element> = Vec::with_capacity(hint);
         while let Some(v) = seq.next_element()? {
             vals.push(v);
         }
-        let bits = if vals.is_empty() {
-            1
-        } else {
-            match vals.iter().copied().max().unwrap().ffs() {
-                0 => 1,
-                n => n,
-            }
-        };
+        let bits = IntArray::bits_for_max(vals.iter().copied().max().unwrap_or(0));
         Ok(IntArray::new_with_vec(bits, vals))
     }
 }
 
+/// Deserializes from a flat sequence of unsigned integers.
+///
+/// **Note:** Bit width is not preserved. The width is re-inferred from the
+/// maximum value in the sequence (minimum 1). An all-zeros array always
+/// deserializes with `bits = 1` regardless of the original width. This
+/// matches the behavior of [`IntArray::shape_auto`].
 impl<'de> Deserialize<'de> for IntArray {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use log::{debug, error};
 use rand::Rng;
+use serde::de::{Deserialize, Deserializer, SeqAccess, Visitor};
 use serde::ser::{Serialize, SerializeSeq, Serializer};
 use std::ops::{AddAssign, MulAssign, Range, SubAssign};
 use std::sync::OnceLock;
@@ -538,6 +539,44 @@ impl Serialize for IntArray {
         let mut seq = serializer.serialize_seq(Some(self.length))?;
         self.iter().for_each(|x| seq.serialize_element(&x).unwrap());
         seq.end()
+    }
+}
+
+struct IntArrayVisitor;
+
+impl<'de> Visitor<'de> for IntArrayVisitor {
+    type Value = IntArray;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "a sequence of unsigned integers")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut vals: Vec<Element> = Vec::new();
+        while let Some(v) = seq.next_element()? {
+            vals.push(v);
+        }
+        let bits = if vals.is_empty() {
+            1
+        } else {
+            match vals.iter().copied().max().unwrap().ffs() {
+                0 => 1,
+                n => n,
+            }
+        };
+        Ok(IntArray::new_with_vec(bits, vals))
+    }
+}
+
+impl<'de> Deserialize<'de> for IntArray {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(IntArrayVisitor)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -633,7 +633,35 @@ fn deserialize_empty() {
     let json = serde_json::to_string(&v).unwrap();
     let v2: IntArray = serde_json::from_str(&json).unwrap();
     assert_eq!(v2.length, 0);
-    assert!(v2.bits >= 1);
+    assert_eq!(v2.bits, 1);
+}
+
+// Bit width is NOT preserved: it is re-inferred from the max value.
+// A bits=8 array with max value 7 (fits in 3 bits) deserializes as bits=3.
+#[test]
+fn deserialize_bits_inferred() {
+    let mut v = IntArray::new(8, 3);
+    v.set(0, 1).unwrap();
+    v.set(1, 2).unwrap();
+    v.set(2, 7).unwrap(); // max = 7, ffs(7) = 3 → bits=3, not 8
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: IntArray = serde_json::from_str(&json).unwrap();
+    assert_eq!(v2.bits, 3);
+    assert_eq!(v2.get(2).unwrap(), 7);
+    // write up to the re-inferred capacity (max = 7 for 3-bit)
+    v2.clone().set(0, 7).unwrap();
+}
+
+#[test]
+fn deserialize_u64_max() {
+    let mut v = IntArray::new(64, 2);
+    v.set(0, u64::MAX).unwrap();
+    v.set(1, 0).unwrap();
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: IntArray = serde_json::from_str(&json).unwrap();
+    assert_eq!(v2.bits, 64);
+    assert_eq!(v2.get(0).unwrap(), u64::MAX);
+    assert_eq!(v2.get(1).unwrap(), 0);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -599,6 +599,54 @@ fn element_add() {
     assert_eq!(a.addval_bits(2, 8).unwrap() & 0xffff, 0x1436);
 }
 
+#[test]
+fn deserialize_json_roundtrip() {
+    let mut v = IntArray::new(4, 5);
+    for i in 0..5 {
+        v.set(i, (i * 3) as u64).unwrap();
+    }
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: IntArray = serde_json::from_str(&json).unwrap();
+    assert_eq!(v.length, v2.length);
+    for i in 0..v.length {
+        assert_eq!(v.get(i).unwrap(), v2.get(i).unwrap());
+    }
+}
+
+#[test]
+fn deserialize_yaml_roundtrip() {
+    let mut v = IntArray::new(8, 4);
+    for i in 0..4 {
+        v.set(i, (i * 50) as u64).unwrap();
+    }
+    let yaml = serde_yaml::to_string(&v).unwrap();
+    let v2: IntArray = serde_yaml::from_str(&yaml).unwrap();
+    assert_eq!(v.length, v2.length);
+    for i in 0..v.length {
+        assert_eq!(v.get(i).unwrap(), v2.get(i).unwrap());
+    }
+}
+
+#[test]
+fn deserialize_empty() {
+    let v = IntArray::new(4, 0);
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: IntArray = serde_json::from_str(&json).unwrap();
+    assert_eq!(v2.length, 0);
+    assert!(v2.bits >= 1);
+}
+
+#[test]
+fn deserialize_all_zeros() {
+    let v = IntArray::new(4, 3);
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: IntArray = serde_json::from_str(&json).unwrap();
+    assert_eq!(v2.length, 3);
+    for i in 0..3 {
+        assert_eq!(v2.get(i).unwrap(), 0);
+    }
+}
+
 /*
     #[bench]
     fn getbench1(b: &mut Bencher) {


### PR DESCRIPTION
Adds a serde Visitor that reads a flat u64 sequence and infers the minimum bit width from the maximum value (same logic as shape_auto). Adds JSON and YAML roundtrip tests plus empty/all-zeros edge cases.