### PR TITLE
push/extend/extend_array/concat return Result instead of panicking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,39 +283,53 @@ impl IntArray {
         mem::size_of::<IntArray>() + (ELEMENT_BITS / 8) * self.data.capacity()
     }
 
-    pub fn push(&mut self, v: Element) -> Option<usize> {
+    /// # Errors
+    /// Returns `Err(TooLarge)` if `v` exceeds the maximum value for this array's bit width.
+    /// The array length is unchanged on error.
+    pub fn push(&mut self, v: Element) -> Result<usize, IntArrayError> {
         self.resize(self.length + 1);
         match self.set(self.length - 1, v) {
-            Ok(_) => Some(self.length - 1),
-            Err(_) => None,
+            Ok(_) => Ok(self.length - 1),
+            Err(e) => {
+                self.resize(self.length - 1);
+                Err(e)
+            }
         }
     }
 
-    pub fn extend<I>(&mut self, vals: I)
+    /// # Errors
+    /// Returns `Err(TooLarge)` if any value exceeds the bit-width maximum.
+    /// The array is unchanged on error (atomic: either all elements are inserted or none are).
+    pub fn extend<I>(&mut self, vals: I) -> Result<(), IntArrayError>
     where
         I: IntoIterator<Item = Element>,
     {
+        let orig = self.length;
         for v in vals {
-            self.push(v).unwrap();
+            if let Err(e) = self.push(v) {
+                self.resize(orig);
+                return Err(e);
+            }
         }
+        Ok(())
     }
 
-    pub fn extend_array(&mut self, vals: IntArray) {
+    pub fn extend_array(&mut self, vals: IntArray) -> Result<(), IntArrayError> {
         let (bpd, _) = IntArray::sizeval(self.bits, 0);
         if vals.bits == self.bits && self.length.is_multiple_of(bpd) {
             // fast path: self is word-aligned, so vals.data slots directly follow
             debug!("fast path: bits={}, length={}", self.bits, self.length);
             self.length += vals.length;
             self.data.extend(vals.data);
-            return;
+            return Ok(());
         }
-        // slow path
+        // slow path: bit-width conversion, atomic via extend()
         debug!("slow path: bits={}, length={}", self.bits, self.length);
-        self.extend(vals.iter());
+        self.extend(vals.iter())
     }
 
-    pub fn concat(&mut self, vals: IntArray) {
-        self.extend_array(vals);
+    pub fn concat(&mut self, vals: IntArray) -> Result<(), IntArrayError> {
+        self.extend_array(vals)
     }
 
     pub fn shape(self: &IntArray, bits: usize) -> IntArray {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -96,13 +96,13 @@ fn extend_fast() {
     let mut v1 = IntArray::new(2, 3);
     let v2 = IntArray::new(10, 20);
     // slow path
-    v1.extend_array(v2);
+    v1.extend_array(v2).unwrap();
     assert_eq!(v1.length, 23);
     assert_eq!(v1.sum().unwrap(), 0);
 
     let mut v3 = IntArray::new(2, 128);
     let v4 = IntArray::new(2, 10);
-    v3.extend_array(v4);
+    v3.extend_array(v4).unwrap();
     assert_eq!(v3.length, 138);
     assert_eq!(v3.sum().unwrap(), 0);
 
@@ -111,7 +111,7 @@ fn extend_fast() {
     let mut v5 = IntArray::new_with_iter(2, [0, 1, 2, 3].iter().cycle().take(32).map(|&x| x));
     let v6 = IntArray::new_with_iter(2, [1, 2, 3, 0].iter().cycle().take(32).map(|&x| x));
     let expected_sum = v5.sum().unwrap() + v6.sum().unwrap();
-    v5.extend_array(v6);
+    v5.extend_array(v6).unwrap();
     assert_eq!(v5.length, 64);
     assert_eq!(v5.sum().unwrap(), expected_sum);
     assert_eq!(v5.get(32).unwrap(), 1); // first element of appended data visible
@@ -308,12 +308,43 @@ fn test_bits() {
 #[test]
 fn pushpop() {
     let mut v = IntArray::new_with_vec(2, vec![0, 1, 2]);
-    v.push(3);
+    v.push(3).unwrap();
     assert_eq!(v.pop().unwrap(), 3);
     assert_eq!(v.pop().unwrap(), 2);
     assert_eq!(v.pop().unwrap(), 1);
     assert_eq!(v.pop().unwrap(), 0);
     assert!(v.pop().is_err()); // must not panic on empty
+}
+
+#[test]
+fn push_too_large() {
+    let mut v = IntArray::new(2, 0); // max value = 3
+    assert_eq!(v.push(4), Err(IntArrayError::TooLarge));
+    assert_eq!(v.length, 0); // array must not grow on failure
+}
+
+#[test]
+fn extend_too_large() {
+    let mut v = IntArray::new(2, 0); // max value = 3
+    assert_eq!(v.extend(vec![1u64, 2, 4]), Err(IntArrayError::TooLarge));
+    assert_eq!(v.length, 0); // atomic: array unchanged on error
+}
+
+#[test]
+fn extend_array_too_large() {
+    // slow path (different bit widths): atomic rollback on error
+    let mut dst = IntArray::new(2, 0); // max value = 3
+    let src = IntArray::new_with_vec(4, vec![1, 2, 5]); // 5 > 3
+    assert_eq!(dst.extend_array(src), Err(IntArrayError::TooLarge));
+    assert_eq!(dst.length, 0); // atomic: array unchanged on error
+}
+
+#[test]
+fn concat_too_large() {
+    let mut dst = IntArray::new(2, 0); // max value = 3
+    let src = IntArray::new_with_vec(4, vec![0, 4]); // 4 > 3
+    assert_eq!(dst.concat(src), Err(IntArrayError::TooLarge));
+    assert_eq!(dst.length, 0); // atomic: array unchanged on error
 }
 
 #[test]
@@ -328,7 +359,7 @@ fn max_min_empty() {
 fn cat() {
     let mut v1 = IntArray::new_with_vec(2, vec![0, 1, 2]);
     let v2 = IntArray::new_with_vec(3, vec![0, 1, 2]);
-    v1.concat(v2);
+    v1.concat(v2).unwrap();
     assert_eq!(v1.length, 6);
     assert_eq!(v1.get(3).unwrap(), 0);
 }
@@ -494,14 +525,14 @@ fn error_types() {
 fn extend_into_iter() {
     let mut v = IntArray::new(4, 0);
     // IntoIterator: pass a Vec directly (not .iter())
-    v.extend(vec![1u64, 2, 3]);
+    v.extend(vec![1u64, 2, 3]).unwrap();
     assert_eq!(v.length, 3);
     assert_eq!(v.get(0).unwrap(), 1);
     assert_eq!(v.get(1).unwrap(), 2);
     assert_eq!(v.get(2).unwrap(), 3);
 
     // IntoIterator: pass a range
-    v.extend(4u64..7);
+    v.extend(4u64..7).unwrap();
     assert_eq!(v.length, 6);
     assert_eq!(v.get(3).unwrap(), 4);
     assert_eq!(v.get(5).unwrap(), 6);


### PR DESCRIPTION
- push: Option<usize> → Result<usize, IntArrayError>; also fixes a latent bug where the array grew even when the value didn't fit (now resizes back on Err)
- extend: () → Result<(), IntArrayError>; propagates push errors
- extend_array/concat: () → Result<(), IntArrayError> for consistency; the slow path (bit-width conversion) could already produce TooLarge
- Update all test call sites with .unwrap()
- Add push_too_large and extend_too_large tests