### PR TITLE
bump v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intarray"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Watanabe Takashi <wtnb75@gmail.com>"]
 edition = "2021"
 rust-version = "1.87"

--- a/README.md
+++ b/README.md
@@ -1,30 +1,35 @@
 # intarray
 
-Memory-efficient packed integer arrays for Rust.
+Memory-efficient packed arrays for Rust. Five types covering unsigned integers, signed integers, floating-point, arbitrary-precision integers, and exact rationals — all with no per-element heap allocation.
 
 - **`IntArray`** — N-bit unsigned integers packed into `Vec<u64>`. Store 1–64 bits per element with no per-element overhead.
 - **`RadixArray`** — Signed integers in an arbitrary range `[A, B]`, packed using mixed-radix encoding. Maximizes elements per 64-bit word for any value range.
+- **`FloatArray`** — Floating-point values stored at a custom bit precision (exponent + mantissa bits). Supports FLOAT16, BFLOAT16, FLOAT32, FLOAT64, and any user-defined format.
+- **`VarIntArray`** — Arbitrary-precision integers (`num_bigint::BigInt`) compressed with Elias gamma + zigzag encoding. Block-based storage for random access.
+- **`RatioArray`** — Exact rational numbers (`num_rational::Ratio<BigInt>`) with no rounding error. Numerator and denominator are each Elias-gamma encoded.
 
 ## When to use
 
-| | `IntArray` | `RadixArray` |
-|---|---|---|
-| Value type | `u64` (unsigned) | `i64` (signed) |
-| Range constraint | 1–64 bits | any `[A, B]` |
-| Best for | bit-width known at design time | range known at runtime |
+| | `IntArray` | `RadixArray` | `FloatArray` | `VarIntArray` | `RatioArray` |
+|---|---|---|---|---|---|
+| Value type | `u64` | `i64` | `f64` | `BigInt` | `Ratio<BigInt>` |
+| Precision | fixed bits | fixed range | custom exp+man | arbitrary | arbitrary |
+| Bounded values | yes | yes | no | no | no |
+| Exact arithmetic | — | — | no | yes | yes |
+| Best for | bit-width known at design time | range known at runtime | compact floats | large unbounded ints | rounding-free rationals |
 
-Both types: memory is the bottleneck, values are bounded, no per-element allocation.
+All types: memory is the bottleneck, no per-element heap allocation.
 
 ## Installation
 
 ```toml
 [dependencies]
-intarray = "0.3"
+intarray = "0.4"
 ```
 
 ## Error type
 
-Both types share a single error enum:
+All types share a single error enum:
 
 ```rust
 pub enum ArrayError {
@@ -32,7 +37,7 @@ pub enum ArrayError {
     TooLarge,      // value exceeds upper bound
     TooSmall,      // value is below lower bound
     Empty,         // pop() on empty array
-    InvalidRange,  // RadixArray: K < 2 or K > u64::MAX
+    InvalidRange,  // invalid construction parameters
 }
 ```
 
@@ -262,25 +267,294 @@ v.datasize();      // total size in bytes
 
 ---
 
+## FloatArray
+
+Stores `f64` values at a reduced precision defined by `(exp_bits, man_bits)`. Each value is re-encoded into the custom format on write and decoded back to `f64` on read. Four predefined formats are provided as constants.
+
+| Constant | exp | man | total bits | notes |
+|---|---|---|---|---|
+| `FLOAT64` | 11 | 52 | 64 | standard `f64` |
+| `FLOAT32` | 8 | 23 | 32 | standard `f32` |
+| `FLOAT16` | 5 | 10 | 16 | IEEE 754 half |
+| `BFLOAT16` | 8 | 7 | 16 | Google Brain float |
+
+### Quick start
+
+```rust
+use intarray::{FloatArray, FLOAT32};
+
+// 32-bit floats, block size 64
+let mut v = FloatArray::new(FLOAT32.0, FLOAT32.1, 0).unwrap();
+
+v.push(3.14).unwrap();
+v.push(-1.0).unwrap();
+assert!((v.get(0).unwrap() - 3.14f64).abs() < 1e-6);
+
+v.sum().unwrap();      // → ~2.14
+v.min().unwrap();      // → ~-1.0
+v.average().unwrap();  // → ~1.07
+```
+
+### Construction
+
+```rust
+use intarray::{FloatArray, FLOAT16, FLOAT32, FLOAT64, BFLOAT16};
+
+// Using a predefined format
+let v = FloatArray::new(FLOAT32.0, FLOAT32.1, 100).unwrap();
+
+// Custom format: 6-bit exponent, 9-bit mantissa (16 bits total)
+let v = FloatArray::new(6, 9, 0).unwrap();
+
+// From a Vec
+let v = FloatArray::new_with_vec(FLOAT32.0, FLOAT32.1, vec![1.0, 2.0, 3.0]).unwrap();
+
+// From an iterator
+let v = FloatArray::new_with_iter(FLOAT16.0, FLOAT16.1, [0.5, 1.0, 1.5]).unwrap();
+```
+
+### Element access
+
+```rust
+let mut v = FloatArray::new(FLOAT32.0, FLOAT32.1, 4).unwrap();
+
+v.set(0, 1.5).unwrap();
+v.get(0).unwrap();         // → ~1.5
+v.push(42.0).unwrap();     // append, returns new index
+v.pop().unwrap();          // remove last, returns value
+```
+
+### Iteration and statistics
+
+```rust
+let v = FloatArray::new_with_vec(FLOAT32.0, FLOAT32.1, vec![1.0, 2.0, 3.0]).unwrap();
+
+for x in v.iter() { println!("{}", x); }
+
+v.sum().unwrap();      // → ~6.0
+v.min().unwrap();      // → ~1.0
+v.max().unwrap();      // → ~3.0
+v.average().unwrap();  // → ~2.0
+```
+
+### Metadata
+
+```rust
+v.len();
+v.bits_per_unit();    // = 1 + exp_bits + man_bits
+v.datasize();         // total size in bytes
+```
+
+---
+
+## VarIntArray
+
+Stores arbitrary-precision signed integers (`num_bigint::BigInt`) using Elias gamma + zigzag encoding. Elements are grouped into blocks of `k` for O(1) amortized `push` and O(k) `get`/`set`.
+
+Memory usage scales with the actual values stored: small values (near zero) use fewer bits.
+
+### Quick start
+
+```rust
+use intarray::VarIntArray;
+use num_bigint::BigInt;
+
+let mut v = VarIntArray::new(64).unwrap();  // block size = 64
+
+v.push(BigInt::from(0)).unwrap();
+v.push(BigInt::from(-1)).unwrap();
+v.push(BigInt::from(i64::MAX)).unwrap();
+v.push("123456789012345678901234567890".parse::<BigInt>().unwrap()).unwrap();
+
+assert_eq!(v.get(1).unwrap(), BigInt::from(-1));
+assert_eq!(v.len(), 4);
+```
+
+### Construction
+
+```rust
+use num_bigint::BigInt;
+
+let v = VarIntArray::new(64).unwrap();
+
+let v = VarIntArray::new_with_vec(32, vec![
+    BigInt::from(1),
+    BigInt::from(-2),
+    BigInt::from(1000),
+]).unwrap();
+
+let v = VarIntArray::new_with_iter(64, (0i64..100).map(BigInt::from)).unwrap();
+```
+
+### Element access
+
+```rust
+let mut v = VarIntArray::new_with_vec(4, vec![
+    BigInt::from(1), BigInt::from(2), BigInt::from(3),
+]).unwrap();
+
+v.get(0).unwrap();                        // → BigInt::from(1)
+v.set(1, BigInt::from(-99)).unwrap();     // decode block, replace, re-encode
+v.push(BigInt::from(42)).unwrap();        // append
+v.pop().unwrap();                         // remove last
+```
+
+### Iteration and statistics
+
+```rust
+let v = VarIntArray::new_with_vec(64, vec![
+    BigInt::from(10), BigInt::from(-3), BigInt::from(7),
+]).unwrap();
+
+for x in v.iter() { println!("{}", x); }
+
+v.sum().unwrap();      // → BigInt::from(14)
+v.min().unwrap();      // → BigInt::from(-3)
+v.max().unwrap();      // → BigInt::from(10)
+v.average().unwrap();  // → ~4.666... (f64, None if empty)
+```
+
+### Metadata
+
+```rust
+v.len();
+v.block_size();    // k
+v.block_count();   // number of blocks
+v.datasize();      // total size in bytes
+```
+
+---
+
+## RatioArray
+
+Stores exact rational numbers (`num_rational::Ratio<BigInt>`) with no rounding error. The numerator is zigzag + Elias gamma encoded; the denominator (always ≥ 1) uses standard Elias gamma. Integers (denominator = 1) cost only 1 extra bit over `VarIntArray`.
+
+`average()` returns an exact `Ratio<BigInt>`, not a float.
+
+### Quick start
+
+```rust
+use intarray::RatioArray;
+use num_bigint::BigInt;
+use num_rational::Ratio;
+
+let mut v = RatioArray::new(64).unwrap();
+
+v.push(Ratio::from_integer(BigInt::from(0))).unwrap();
+v.push(Ratio::new(BigInt::from(1), BigInt::from(2))).unwrap();   // 1/2
+v.push(Ratio::new(BigInt::from(-1), BigInt::from(3))).unwrap();  // -1/3
+v.push(Ratio::new(BigInt::from(22), BigInt::from(7))).unwrap();  // 22/7
+
+assert_eq!(v.get(1).unwrap(), Ratio::new(BigInt::from(1), BigInt::from(2)));
+assert_eq!(v.len(), 4);
+```
+
+### Construction
+
+```rust
+use num_bigint::BigInt;
+use num_rational::Ratio;
+
+let v = RatioArray::new(64).unwrap();
+
+let v = RatioArray::new_with_vec(32, vec![
+    Ratio::from_integer(BigInt::from(1)),
+    Ratio::new(BigInt::from(1), BigInt::from(2)),
+]).unwrap();
+
+let v = RatioArray::new_with_iter(64, [
+    Ratio::from_integer(BigInt::from(0)),
+    Ratio::new(BigInt::from(3), BigInt::from(4)),
+]).unwrap();
+```
+
+### Element access
+
+```rust
+let mut v = RatioArray::new_with_vec(4, vec![
+    Ratio::from_integer(BigInt::from(1)),
+    Ratio::from_integer(BigInt::from(2)),
+]).unwrap();
+
+v.get(0).unwrap();    // → 1/1
+v.set(0, Ratio::new(BigInt::from(3), BigInt::from(7))).unwrap();
+v.push(Ratio::new(BigInt::from(1), BigInt::from(6))).unwrap();
+v.pop().unwrap();
+```
+
+### Iteration and statistics
+
+```rust
+use num_bigint::BigInt;
+use num_rational::Ratio;
+
+let v = RatioArray::new_with_vec(4, vec![
+    Ratio::new(BigInt::from(1), BigInt::from(2)),   // 1/2
+    Ratio::new(BigInt::from(1), BigInt::from(3)),   // 1/3
+    Ratio::new(BigInt::from(1), BigInt::from(6)),   // 1/6
+]).unwrap();
+
+for x in v.iter() { println!("{}", x); }
+
+v.sum().unwrap();      // → Ratio = 1  (exact: 1/2 + 1/3 + 1/6 = 1)
+v.min().unwrap();      // → 1/6
+v.max().unwrap();      // → 1/2
+v.average().unwrap();  // → Ratio = 1/3  (exact, no float rounding)
+```
+
+### Metadata
+
+```rust
+v.len();
+v.block_size();    // k
+v.block_count();   // number of blocks
+v.datasize();      // total size in bytes
+```
+
+---
+
 ## Serialization (serde)
 
-Both types serialize as flat sequences.
+All types serialize as flat sequences. Internal parameters (bit width, range, block size) are not preserved; they are re-inferred or reset to defaults on deserialization.
 
 ```rust
 use serde_json;
 
-// IntArray → [u64, ...]
+// IntArray → JSON array of u64
 let v = IntArray::new_with_vec(4, vec![1u64, 2, 3]).unwrap();
 let json = serde_json::to_string(&v).unwrap();   // "[1,2,3]"
 let v2: IntArray = serde_json::from_str(&json).unwrap();
 // Bit width re-inferred from max value on deserialize.
 
-// RadixArray → [i64, ...]
+// RadixArray → JSON array of i64
 let r = RadixArray::new_with_vec(-5, 5, vec![-1i64, 0, 2]).unwrap();
 let json = serde_json::to_string(&r).unwrap();   // "[-1,0,2]"
 let r2: RadixArray = serde_json::from_str(&json).unwrap();
 // Range [A, B] re-inferred from min/max on deserialize.
+
+// FloatArray → JSON array of f64
+let f = FloatArray::new_with_vec(FLOAT32.0, FLOAT32.1, vec![1.0, 2.0]).unwrap();
+let json = serde_json::to_string(&f).unwrap();   // "[1.0,2.0]"
+let f2: FloatArray = serde_json::from_str(&json).unwrap();
+// Format defaults to FLOAT64 on deserialize.
+
+// VarIntArray → JSON array of decimal strings (arbitrary precision)
+let vi = VarIntArray::new_with_vec(4, vec![BigInt::from(-1), BigInt::from(2)]).unwrap();
+let json = serde_json::to_string(&vi).unwrap();  // "["-1","2"]"
+let vi2: VarIntArray = serde_json::from_str(&json).unwrap();
+// Block size k defaults to 64 on deserialize.
+
+// RatioArray → JSON array of "p/q" strings (integers as "p")
+let ra = RatioArray::new_with_vec(4, vec![
+    Ratio::new(BigInt::from(1), BigInt::from(2)),
+    Ratio::from_integer(BigInt::from(-3)),
+]).unwrap();
+let json = serde_json::to_string(&ra).unwrap();  // "["1/2","-3"]"
+let ra2: RatioArray = serde_json::from_str(&json).unwrap();
+// Block size k defaults to 64 on deserialize.
 ```
+
+`PartialEq` for `VarIntArray` and `RatioArray` compares elements only (ignoring block size `k`), so a serde round-trip always compares equal.
 
 ## MSRV
 

--- a/SPEC_float.md
+++ b/SPEC_float.md
@@ -1,0 +1,251 @@
+# FloatArray 仕様
+
+## 概要
+
+`FloatArray` は、仮数部ビット数 `man_bits` と指数部ビット数 `exp_bits` を実行時に指定できる、
+カスタム精度浮動小数点数のパック配列である。
+
+各要素は `1 + exp_bits + man_bits` ビットを消費し、`Vec<u64>` に詰め込んで格納する。
+ユーザーへの公開型は `f64`（get/set のインターフェイス）。
+
+既存の `IntArray`（N-bit 符号なし整数配列）および `RadixArray`（任意範囲符号あり整数配列）と
+同一の `PackedArrayCore` トレイトを実装し、push/pop/extend の共通ロジックを共有する。
+
+---
+
+## ビットフォーマット
+
+要素は IEEE 754 ライクな固定フォーマットで格納する：
+
+```
+bit[total-1]                          : sign (1 bit)
+bit[man_bits .. man_bits+exp_bits-1]  : exponent (exp_bits bits, biased) ※両端を含む
+bit[0 .. man_bits-1]                  : mantissa (man_bits bits) ※両端を含む
+```
+
+数値例（FLOAT16: exp_bits=5, man_bits=10, total=16）：
+```
+bit15      : sign
+bit14..10  : exponent (5 bits)
+bit9..0    : mantissa (10 bits)
+```
+
+- `total = 1 + exp_bits + man_bits`
+- `bias = 2^(exp_bits-1) - 1`
+- `exp_max = 2^exp_bits - 1`（全ビット1 = Inf/NaN を示す予約値）
+
+これは IEEE 754 のエンコーディング規則に従い、標準フォーマット（float16, bfloat16, float32, float64）と
+ビットレベルで互換性がある。
+
+---
+
+## 標準フォーマット定数
+
+```rust
+pub const FLOAT16:  (usize, usize) = (5,  10);  // IEEE 754 半精度
+pub const BFLOAT16: (usize, usize) = (8,   7);  // Brain Float 16
+pub const FLOAT32:  (usize, usize) = (8,  23);  // IEEE 754 単精度
+pub const FLOAT64:  (usize, usize) = (11, 52);  // IEEE 754 倍精度
+```
+
+---
+
+## パッキング方式
+
+`IntArray` と同じビット詰め方式（詳細は `SPEC_intarray.md` §パッキング方式を参照）。
+`bits` を `total = 1 + exp_bits + man_bits` に置き換えたものが FloatArray のパッキング。
+
+```
+bpu = 64 / total          // elements per u64 word（小数切り捨て）
+word_count = ceil(len / bpu)
+
+word_index = i / bpu
+bit_offset = (i % bpu) * total
+mask = (1u64 << total) - 1  // total == 64 のとき u64::MAX
+
+get:  (data[word_index] >> bit_offset) & mask
+set:  data[word_index] = (data[word_index] & !(mask << bit_offset))
+                        | (encoded << bit_offset)
+```
+
+| フォーマット | total | bpu |
+|---|---|---|
+| FLOAT16 / BFLOAT16 | 16 | 4 |
+| FLOAT32 | 32 | 2 |
+| FLOAT64 | 64 | 1 |
+| カスタム 8bit (2e+5m) | 8 | 8 | ※ exp_bits=2 だと表現範囲が [1.0, 4.0) のみ。実験的用途向け |
+
+---
+
+## 構成パラメータの制約
+
+`new(exp_bits, man_bits, len)` は以下を検証し、違反時に `Err(ArrayError::InvalidRange)` を返す：
+
+| 条件 | 理由 |
+|---|---|
+| `exp_bits >= 2` | exp=0 をゼロ、exp=all1 を Inf/NaN に予約するため最低 2 bit 必要 |
+| `exp_bits <= 11` | インターフェイスが f64 のため、f64 の指数部幅 (11 bit) を超えても範囲は広がらない |
+| `man_bits >= 1` | 仮数部が 0 bit だと精度が完全に失われる |
+| `man_bits <= 52` | インターフェイスが f64 のため、f64 の仮数部幅 (52 bit) を超えても精度は向上しない |
+| `1 + exp_bits + man_bits <= 64` | u64 に収まること（前 2 条件から自動的に満たされるが、意図を明示するため検証する） |
+
+> **精度の上限**: インターフェイスが `f64` である以上、実効精度の上限は FLOAT64（11e + 52m）。
+> `exp_bits > 11` または `man_bits > 52` は意味のないビット消費になるためエラーとする。
+
+---
+
+## エンコーディング規則（f64 → カスタムフォーマット）
+
+1. `v.to_bits()` から `sign`, `f64_exp`, `f64_man` を取り出す。
+2. **NaN / Inf** (`f64_exp == 0x7FF`):
+   - `custom_exp = exp_max`（全ビット1）
+   - Inf: `custom_man = 0`
+   - NaN: `custom_man = 1`（ペイロードは正規化せず最小 NaN）
+3. **ゼロ / 非正規化数** (`f64_exp == 0`):
+   - Flush-to-zero: 符号ビットのみ保持、指数・仮数は 0
+4. **通常値**:
+   - `custom_exp = f64_exp - 1023 + bias`
+   - `custom_exp >= exp_max` → オーバーフロー → ±Inf として格納（エラーにしない）
+   - `custom_exp <= 0` → アンダーフロー → ±0 として格納（エラーにしない）
+   - 仮数の切り詰め（truncate）: `f64_man >> (52 - man_bits)`（man_bits ≤ 52 の場合）
+
+## デコーディング規則（カスタムフォーマット → f64）
+
+1. `raw` から `sign`, `custom_exp`, `custom_man` を取り出す。
+2. `custom_exp == exp_max` → Inf（`custom_man == 0`）または NaN（`custom_man != 0`）。
+3. `custom_exp == 0` → ±0.0（flush-to-zero で非正規化数は存在しない）。
+4. 通常値:
+   - `f64_exp = custom_exp - bias + 1023`（u64 にキャスト）
+   - 仮数の拡張（ゼロ埋め）: `f64_man = custom_man << (52 - man_bits)`
+   - `f64::from_bits((sign << 63) | (f64_exp << 52) | f64_man)`
+
+---
+
+## API
+
+### 構築
+
+```rust
+// 全要素を +0.0 で初期化（全ビット0 → 符号=0、指数=0、仮数=0）
+FloatArray::new(exp_bits, man_bits, len) -> Result<Self, ArrayError>
+
+// Vec<f64> から構築
+FloatArray::new_with_vec(exp_bits, man_bits, vals: Vec<f64>) -> Result<Self, ArrayError>
+
+// イテレータから構築
+FloatArray::new_with_iter(exp_bits, man_bits, vals: impl Iterator<Item=f64>) -> Result<Self, ArrayError>
+```
+
+### 要素アクセス
+
+```rust
+get(i: usize) -> Result<f64, ArrayError>   // Err(OutOfBounds) のみ
+set(i: usize, v: f64) -> Result<(), ArrayError>  // Err(OutOfBounds) のみ
+```
+
+値の範囲エラーは発生しない（オーバーフロー→Inf、アンダーフロー→0 として格納）。
+
+### スタック操作
+
+```rust
+push(v: f64) -> Result<usize, ArrayError>   // 戻り値は新要素のインデックス
+pop() -> Result<f64, ArrayError>            // Err(Empty)
+```
+
+push は値のエラーで失敗しない（任意の f64 を格納可能）。
+
+### 一括操作
+
+```rust
+extend(vals: impl IntoIterator<Item=f64>) -> Result<(), ArrayError>
+extend_array(other: &FloatArray) -> Result<(), ArrayError>
+```
+
+`extend` は値エラーで失敗しないため、常に `Ok(())` を返す（任意の f64 を格納可能なため）。
+ただし実装は IntArray/RadixArray と同じ `PackedArrayCore::core_extend` を使用し、
+仮に将来エラーが発生した場合のロールバック機構も共有している。
+
+`extend_array` はフォーマットが一致し、`self` が word-aligned（`length % bpu == 0`）の場合に
+raw word コピーの fast path を使用する。それ以外は要素ごとに decode(f64) → encode を経由する slow path。
+
+### 統計
+
+```rust
+iter() -> FloatIter           // ExactSizeIterator<Item=f64>; インデックス 0 から順に返す
+sum() -> Option<f64>          // None if empty
+min() -> Option<f64>          // None if empty; NaN があれば他の値を優先
+max() -> Option<f64>          // 同上
+average() -> Option<f64>      // None if empty
+```
+
+min/max は `f64::min` / `f64::max` を使い、NaN があれば非 NaN 側を返す（NaN は「値なし」扱い）。
+ただし全要素が NaN の場合は NaN を返す。
+
+`sum()` / `average()` は NaN を含む場合 NaN を返す（f64 加算の伝播による）。
+
+### メタデータ
+
+```rust
+len() -> usize
+is_empty() -> bool
+exp_bits() -> usize
+man_bits() -> usize
+capacity() -> usize     // data.len() * bpu
+datasize() -> usize     // 構造体 + Vec データのバイト数
+```
+
+---
+
+## エラー型
+
+`FloatArray` が返す `ArrayError` の種類：
+
+| エラー | 発生箇所 |
+|---|---|
+| `OutOfBounds` | `get` / `set` のインデックス超過 |
+| `Empty` | `pop` を空配列に対して呼んだ |
+| `InvalidRange` | `new` でパラメータが制約違反 |
+
+`TooLarge` / `TooSmall` は `FloatArray` では発生しない（サイレント変換）。
+
+---
+
+## 表示 (Display)
+
+```
+[e5m10][4]=1,2,3,4
+  ^  ^  ^
+  |  |  length
+  |  man_bits
+  exp_bits
+```
+
+---
+
+## シリアライズ (serde)
+
+- **Serialize**: 要素を f64 のフラット配列として出力。フォーマット情報は含まない。
+- **Deserialize**: フラット配列から FLOAT64（11e+52m）として再構築。
+
+> **注意**: シリアライズ・デシリアライズで `exp_bits`/`man_bits` は保存されない。
+> 精度を変えて格納していた場合、デシリアライズ後は FLOAT64 精度になる。
+
+---
+
+## 設計上の決定事項
+
+| 項目 | 決定 | 理由 |
+|---|---|---|
+| 非正規化数 | Flush-to-zero | 実装シンプル、ML/センサーデータ用途では十分 |
+| NaN | NaN として保存・復元するが、ペイロードは正規化（`custom_man=1` に統一） | ペイロード保存は複雑でユースケースがほぼない |
+| Inf | ±Inf として保存・復元 | 数値計算の正確性のため |
+| 仮数の丸め | 切り捨て (truncate) | 高速、実装シンプル |
+| オーバーフロー | ±Inf に変換（エラーなし） | float らしい振る舞い |
+| アンダーフロー | ±0 に変換（エラーなし） | flush-to-zero と一致 |
+| ユーザー型 | `f64` | Rust の標準浮動小数点型 |
+
+---
+
+## 疑問点・未解決事項
+
+（現時点ではなし）

--- a/SPEC_intarray.md
+++ b/SPEC_intarray.md
@@ -1,0 +1,243 @@
+# IntArray 仕様
+
+## 概要
+
+`IntArray` は、1〜64 ビットの符号なし整数を `Vec<u64>` にビット詰めして格納するパック配列である。
+要素型は `u64`（内部型エイリアス `Element`）。
+
+メモリ効率を最大化するため、各要素は `bits` ビットだけを消費し、
+複数の要素を1つの `u64` ワードに隙間なく詰め込む。
+
+---
+
+## パッキング方式（ビット詰め）
+
+```
+bpd = 64 / bits          // elements per word（小数切り捨て）
+word_count = ceil(len / bpd)
+```
+
+要素 `i` の格納位置：
+```
+word_index = i / bpd
+bit_position = i % bpd
+bit_offset = bit_position * bits
+
+get:  (data[word_index] >> bit_offset) & max_value
+set:  data[word_index] = (data[word_index] & !(max_value << bit_offset))
+                        | (v << bit_offset)
+```
+
+- `max_value = (1u64 << bits) - 1`（bits < 64 の場合）、または `u64::MAX`（bits == 64 の場合）
+- `bits` が 64 を割り切れない場合、各ワードの上位ビットは未使用（常に 0）
+- 最終ワードも同様に部分的に使用される場合がある
+
+### パッキング効率
+
+| bits | bpd | 効率 |
+|---|---|---|
+| 1 | 64 | 100% |
+| 4 | 16 | 100% |
+| 7 | 9 | 98.4%（63/64 bit 使用） |
+| 8 | 8 | 100% |
+| 10 | 6 | 93.8% |
+| 16 | 4 | 100% |
+| 32 | 2 | 100% |
+| 64 | 1 | 100% |
+
+---
+
+## 構成パラメータの制約
+
+`bits` は `1 ≤ bits ≤ 64` を満たさなければならない。
+違反した場合、コンストラクタは **panic** する（`Result` を返さない）。
+
+---
+
+## API
+
+### 構築
+
+```rust
+// 全要素を 0 で初期化。bits が範囲外なら panic。
+IntArray::new(bits: usize, len: usize) -> IntArray
+
+// Vec<u64> から構築。値が max_value を超えると panic。
+IntArray::new_with_vec(bits: usize, vals: Vec<u64>) -> IntArray
+
+// イテレータから構築。値が max_value を超えると panic。
+// 内部で 1024 要素単位にバッファし、最後に resize する。
+IntArray::new_with_iter(bits: usize, vals: impl Iterator<Item=u64>) -> IntArray
+```
+
+> **注意**: `new_with_vec` / `new_with_iter` は `Result` を返さず、
+> 範囲外の値が渡された場合は panic する。
+> 呼び出し側で事前にバリデーションするか、`push` / `extend`（Result を返す）を使うこと。
+
+### 要素アクセス
+
+```rust
+get(i: usize) -> Result<u64, ArrayError>   // Err(OutOfBounds)
+set(i: usize, v: u64) -> Result<(), ArrayError>  // Err(OutOfBounds) / Err(TooLarge)
+max_value() -> u64                          // 格納可能な最大値 = 2^bits - 1
+```
+
+### インクリメント／デクリメント
+
+```rust
+incr(i: usize) -> Result<(), ArrayError>   // v[i] += 1。max_value で Err(TooLarge)
+decr(i: usize) -> Result<(), ArrayError>   // v[i] -= 1。0 で Err(TooSmall)
+add(i: usize, v: u64) -> Result<(), ArrayError>
+sub(i: usize, v: u64) -> Result<(), ArrayError>
+
+// 境界でエラーではなく None を返す（クランプ）
+incr_limit(i: usize) -> Option<u64>   // 成功時は変更前の値を返す。既に max なら None
+decr_limit(i: usize) -> Option<u64>   // 成功時は変更前の値を返す。既に 0 なら None
+```
+
+### スタック操作
+
+```rust
+push(v: u64) -> Result<usize, ArrayError>   // 戻り値は追加した要素のインデックス
+pop() -> Result<u64, ArrayError>            // Err(Empty)
+```
+
+`push` は `v > max_value` のとき `Err(TooLarge)` を返し、配列は変化しない。
+
+### 一括操作
+
+```rust
+extend(vals: impl IntoIterator<Item=u64>) -> Result<(), ArrayError>
+extend_array(other: &IntArray) -> Result<(), ArrayError>
+```
+
+`extend` は atomic: 途中でエラーが発生した場合、元の長さまでロールバックする。
+
+`extend_array` の fast path: `self.bits == other.bits` かつ `self.length % bpd == 0` のとき、
+raw ワードをそのままコピーする（要素ごとの get/set をスキップ）。
+それ以外は slow path（要素ごとに `get` → `set`）。
+
+### 形状変換
+
+```rust
+shape(bits: usize) -> IntArray      // 異なるビット幅に変換（全要素コピー）
+shape_auto() -> IntArray            // max 値から最小ビット幅を自動推定して変換
+subarray(offset: usize, length: usize) -> IntArray  // 部分配列の抽出
+```
+
+`subarray` の fast path: `offset % bpd == 0` のとき raw ワードコピー。
+
+### 統計
+
+```rust
+iter() -> IntIter        // インデックス 0 から順に u64 を返す
+sum() -> Option<u128>    // None if empty
+min() -> Option<u64>     // None if empty
+max() -> Option<u64>     // None if empty
+average() -> Option<f64> // None if empty
+```
+
+`sum` は `bits ≤ 32` のとき SIMD ライクなワード単位の並列加算で高速化する（後述）。
+
+### 乱数充填
+
+```rust
+fill_random(&mut self)
+```
+
+全要素を `[0, max_value]` の一様乱数で埋める。
+`bits` が 64 を割り切る場合は `bpd - 1` ワードを丸ごとランダム生成（高速）。
+最終ワードは要素ごとに設定する。
+
+### メタデータ
+
+```rust
+len() -> usize
+is_empty() -> bool
+capacity() -> usize    // data.len() * bpd（確保済みの要素数）
+datasize() -> usize    // 構造体 + Vec データのバイト数
+```
+
+---
+
+## エラー型
+
+`IntArray` が返す `ArrayError` の種類：
+
+| エラー | 発生箇所 |
+|---|---|
+| `OutOfBounds` | `get` / `set` のインデックス超過 |
+| `TooLarge` | `set` / `push` / `add` / `incr` で値が `max_value` を超える |
+| `TooSmall` | `sub` / `decr` で値が 0 を下回る |
+| `Empty` | `pop` を空配列に対して呼んだ |
+
+---
+
+## 算術演算子
+
+要素ごとのインプレース演算。スカラー `u64` と `&IntArray` の両方をサポート。
+
+```rust
+arr += scalar: u64    // 全要素に scalar を加算
+arr -= scalar: u64    // 全要素から scalar を減算
+arr *= scalar: u64    // 全要素に scalar を乗算
+arr += &other         // 要素ごとに加算（長さが異なれば短い方に合わせる）
+arr -= &other         // 要素ごとに減算
+```
+
+オーバーフロー・アンダーフロー時は `unwrap()` によって panic する。
+
+スカラー演算・同一 bits 長 `IntArray` 演算の fast path: ワード単位の並列演算（`add_bits` / `sub_bits` / `mul_bits`）を使用。異なる bits または長さの場合は slow path（要素ごとの get/set）。
+
+---
+
+## sum の高速化（bits ≤ 32 のとき）
+
+同一ワード内の複数要素を1回の演算でまとめて加算する再帰的な並列加算：
+
+```
+初期: 1ワードに n 個の bits-bit 要素が詰まっている
+step1: マスクで偶数・奇数スロットを分離して加算 → 2*bits-bit 要素が n/2 個になる
+step2: 同様に繰り返す
+...
+最終: 64-bit の合計が1つ残る
+```
+
+この最適化は `bits ≤ 32`（= 1ワードに2要素以上入る）のときのみ有効。
+`bits > 32` のときは `sum0()`（イテレータによる逐次加算）にフォールバック。
+
+---
+
+## 表示 (Display)
+
+```
+4[10]=0,1,2,3,4,5,6,7,8,9
+^  ^
+|  length
+bits
+```
+
+---
+
+## シリアライズ (serde)
+
+- **Serialize**: 要素を `u64` のフラット配列として出力。`bits` 情報は含まない。
+- **Deserialize**: フラット配列から再構築。`bits` は最大値から自動推定（`bits_for_max`）。
+  - 全要素が 0 の場合: `bits = 1`
+  - 最大値が `m` の場合: `bits = floor(log2(m)) + 1`
+
+> **注意**: デシリアライズで `bits` は保存されない。
+> 元の `bits` より小さい値に推定される可能性がある。
+
+---
+
+## 設計上の特記事項
+
+| 項目 | 動作 |
+|---|---|
+| コンストラクタのエラー処理 | panic（`Result` を返さない） |
+| `push` / `extend` のエラー処理 | `Result` を返す |
+| オーバーフロー（演算子） | panic |
+| 未使用ビット（端数ワード） | 常に 0 に保たれる |
+| `bits` の公開フィールド | `pub bits: usize`（読み取り可能） |
+| `length` の公開フィールド | `pub length: usize`（読み取り可能） |

--- a/SPEC_rarray.md
+++ b/SPEC_rarray.md
@@ -1,0 +1,400 @@
+# RadixArray 設計仕様
+
+## 概要
+
+`RadixArray` は整数の範囲 `[A, B]` を持つ値の配列を、混合基数符号化（mixed-radix encoding）によってメモリ効率良く格納するデータ構造。
+
+既存の `IntArray`（N ビット詰め）とは異なり、1 ワード（u64）を基数 K の数として扱い、各要素をその桁として表現する。K が 2 の冪でない場合、必ずビット詰めより多くの要素を 1 ワードに格納できる。
+
+## 数学的根拠
+
+### 格納効率
+
+基数 K = B − A + 1、ワードサイズ W = 64 ビットとして：
+
+```
+epu (elements per u64) = floor(64 * ln(2) / ln(K))
+```
+
+epu は「K^epu − 1 ≤ u64::MAX < K^(epu+1) − 1」を満たす最大の整数、
+すなわち「K^epu ≤ 2^64」を満たす最大の整数。
+（2^64 = u64::MAX + 1 は u64 では表現できないため、検証は u128 で行う）
+
+### ビット詰めとの比較
+
+| K | ビット詰め epu | 基数方式 epu | 向上率 |
+|---|---|---|---|
+| 2 | 64 | 64 | 0% |
+| 3 | 32 | 40 | +25% |
+| 5 | 21 | 27 | +29% |
+| 6 | 21 | 24 | +14% |
+| 7 | 21 | 22 | +5% |
+| 8 | 21 | 21 | 0% |
+| 10 | 16 | 19 | +19% |
+| 100 | 7 | 9 | +29% |
+
+K が 2 の冪のとき、基数方式とビット詰めは等価になる。
+
+### 符号化・復号
+
+i 番目の要素のワードインデックスと桁位置：
+
+```
+word_idx = i / epu
+digit_pos = i % epu
+```
+
+**取得（get）:**
+```
+stored = (data[word_idx] / K^digit_pos) % K
+value  = stored + A
+```
+
+**書込（set）:**
+```
+stored_new  = value - A
+stored_old  = (data[word_idx] / K^digit_pos) % K
+data[word_idx] = data[word_idx]
+               - stored_old * K^digit_pos
+               + stored_new * K^digit_pos
+```
+
+## データ構造
+
+```rust
+#[derive(Clone)]  // 全フィールドが Clone を実装するため derive で十分
+pub struct RadixArray {
+    base: u64,          // K = B - A + 1
+    offset: i64,        // A（最小値。get時に加算、set時に減算）
+    epu: usize,         // elements per u64
+    powers: Vec<u64>,   // powers[i] = K^i (i = 0..epu)
+    length: usize,      // 要素数
+    data: Vec<u64>,     // 格納ワード列
+}
+```
+
+### powers テーブル
+
+構築時に一度だけ計算し、get/set で使い回す。
+
+```
+powers[0] = 1
+powers[1] = K
+powers[2] = K^2
+...
+powers[epu-1] = K^(epu-1)
+```
+
+`powers[epu]`（= K^epu）は計算すると u64 をオーバーフローするため格納しない。ワード境界の判定は `i % epu == 0` で行う。
+
+### ワード数
+
+```
+word_count = length.div_ceil(epu)
+```
+
+末尾ワードは部分的に使用される（未使用桁は 0）。
+
+## エラー型
+
+`IntArray` と同じ `IntArrayError` を共用する（依存関係として `intarray` を参照するか、`rarray` クレートに再定義する）。
+
+```rust
+pub enum RadixArrayError {
+    OutOfBounds,   // index >= length
+    TooLarge,      // value > B
+    TooSmall,      // value < A
+    Empty,         // pop() on empty array
+    InvalidRange,  // K < 2 または K > u64::MAX（下記参照）
+}
+```
+
+`IntArrayError` と異なり符号付き整数の範囲（A < 0 も許容）を扱うため、`TooSmall` が追加になる。
+
+## API
+
+### 構築
+
+```rust
+// [A, B] 範囲の要素を len 個確保し、全要素を A で初期化する
+// （内部データは u64 ゼロで初期化され、get すると A が返る）
+pub fn new(a: i64, b: i64, len: usize) -> Result<RadixArray, RadixArrayError>
+
+// Vec<i64> から構築。アトミック：vals に範囲外の値が1つでもあれば Err を返し何も構築しない
+pub fn new_with_vec(a: i64, b: i64, vals: Vec<i64>) -> Result<RadixArray, RadixArrayError>
+
+// イテレータから構築。アトミック：途中で範囲外の値があれば Err を返し何も構築しない
+pub fn new_with_iter<I>(a: i64, b: i64, vals: I) -> Result<RadixArray, RadixArrayError>
+where I: Iterator<Item = i64>
+```
+
+### 要素アクセス
+
+```rust
+pub fn get(&self, i: usize) -> Result<i64, RadixArrayError>
+pub fn set(&mut self, i: usize, v: i64) -> Result<(), RadixArrayError>
+```
+
+### スタック操作（atomic）
+
+```rust
+// 末尾に追加。成功時は新しいインデックスを返す
+pub fn push(&mut self, v: i64) -> Result<usize, RadixArrayError>
+
+// 末尾から取り出す
+pub fn pop(&mut self) -> Result<i64, RadixArrayError>
+```
+
+### バルク操作（すべて atomic）
+
+```rust
+// イテレータから追加。エラー時は配列を元のサイズに戻す
+pub fn extend<I>(&mut self, vals: I) -> Result<(), RadixArrayError>
+where I: IntoIterator<Item = i64>
+
+// 別の RadixArray から追加。vals の各要素を i64 値として取り出し self に push する。
+// self の範囲 [A, B] に収まらない値があれば Err（アトミック）。
+// fast path: vals.base == self.base かつ self.length % self.epu == 0 のとき
+//            raw word をそのままコピーする（get/set を経由しない）。
+// slow path: それ以外は extend(vals.iter()) に委譲。
+pub fn extend_array(&mut self, vals: &RadixArray) -> Result<(), RadixArrayError>
+```
+
+### 情報取得
+
+```rust
+pub fn len(&self) -> usize
+pub fn is_empty(&self) -> bool
+pub fn capacity(&self) -> usize   // data.len() * epu
+pub fn base(&self) -> u64         // K
+pub fn range(&self) -> (i64, i64) // (A, B)
+
+// メモリ使用量（バイト）
+pub fn datasize(&self) -> usize
+```
+
+### イテレータ
+
+```rust
+pub fn iter(&self) -> RadixIter<'_>
+```
+
+`Iterator<Item = i64>` を実装。
+
+### 統計
+
+```rust
+pub fn sum(&self) -> Option<i128>  // i64 ではオーバーフローするため i128
+pub fn min(&self) -> Option<i64>
+pub fn max(&self) -> Option<i64>
+pub fn average(&self) -> Option<f64>
+```
+
+### リサイズ
+
+```rust
+// 内部用。末尾を切り詰めるか拡張する。
+// 拡張時は新規ワードを 0 で初期化するため、追加された要素は get すると A が返る。
+fn resize(&mut self, len: usize)
+```
+
+### Display
+
+```rust
+impl fmt::Display for RadixArray {
+    // 例: "[A,B][5]=-1,0,1,0,-1"
+}
+```
+
+## 実装上の注意点
+
+### K のバリデーション（オーバーフロー対策）
+
+`new` の先頭で i128 を使って K を計算し、範囲を確認する。
+
+```rust
+let k = b as i128 - a as i128 + 1;
+if k < 2 || k > u64::MAX as i128 {
+    return Err(RadixArrayError::InvalidRange);
+}
+let base = k as u64;
+```
+
+- `k < 2`: A ≥ B（A == B で K=1 の場合も含む）
+- `k > u64::MAX`: 実質 A = i64::MIN かつ B = i64::MAX のケースのみ。u64 に収まらないため弾く。
+- i64 同士の減算を直接行うと debug ビルドでパニックするため、必ず i128 にキャストしてから計算する。
+
+### epu の導出
+
+```rust
+fn calc_epu(base: u64) -> usize {
+    // 2^64 = u64::MAX + 1 なので f64 で近似計算し、
+    // 前後を整数検証して確定させる
+    let epu_approx = (64.0 * std::f64::consts::LN_2 / (base as f64).ln()) as usize;
+    // epu_approx - 1, epu_approx, epu_approx + 1 の3候補を u128 で検証
+    // base^epu <= u64::MAX となる最大の epu を返す
+    ...
+}
+```
+
+f64 の精度誤差で ±1 ずれる可能性があるため、u128 で `base^candidate <= u64::MAX` を確認してから確定する。
+
+### powers テーブルの計算
+
+```rust
+fn calc_powers(base: u64, epu: usize) -> Vec<u64> {
+    let mut p = vec![1u64; epu];
+    for i in 1..epu {
+        p[i] = p[i - 1] * base; // オーバーフロー不可（K^(epu-1) <= u64::MAX）
+    }
+    p
+}
+```
+
+`powers[epu-1]` = K^(epu-1) は必ず u64 に収まる（K^epu が u64 を超えない最大の epu を選んでいるため）。
+
+### get / set の実装詳細
+
+```rust
+pub fn get(&self, i: usize) -> Result<i64, RadixArrayError> {
+    if i >= self.length { return Err(RadixArrayError::OutOfBounds); }
+    let (widx, dpos) = (i / self.epu, i % self.epu);
+    let stored = (self.data[widx] / self.powers[dpos]) % self.base;
+    Ok(stored as i64 + self.offset)
+}
+
+pub fn set(&mut self, i: usize, v: i64) -> Result<(), RadixArrayError> {
+    // IntArray と同じ順序: OutOfBounds を先に返す
+    if i >= self.length { return Err(RadixArrayError::OutOfBounds); }
+    if v < self.offset { return Err(RadixArrayError::TooSmall); }
+    if v > self.offset + self.base as i64 - 1 { return Err(RadixArrayError::TooLarge); }
+    let (widx, dpos) = (i / self.epu, i % self.epu);
+    let p = self.powers[dpos];
+    let old = (self.data[widx] / p) % self.base;
+    let new = (v - self.offset) as u64;
+    self.data[widx] = self.data[widx] - old * p + new * p;
+    Ok(())
+}
+```
+
+### extend_array の fast path
+
+```rust
+pub fn extend_array(&mut self, vals: &RadixArray) -> Result<(), RadixArrayError> {
+    if vals.base == self.base && self.length % self.epu == 0 {
+        // fast path: self がワード境界にアラインされており、base が同じ
+        // → vals.data をそのまま連結できる
+        self.length += vals.length;
+        self.data.extend_from_slice(&vals.data);
+        return Ok(());
+    }
+    // slow path: 値を1つずつ取り出して push（アトミック性は extend が保証）
+    self.extend(vals.iter())
+}
+```
+
+fast path が成立する条件：
+- `vals.base == self.base`: ワードの符号化方式が同一
+- `self.length % self.epu == 0`: self の末尾がワード境界にある（末尾ワードが埋まりきっている）
+
+fast path では値の範囲チェックを行わない（同じ base なら vals の各要素は必ず self の範囲に収まる）。
+
+### 末尾ワードの境界
+
+`push` / `resize` で要素を増やす際、新しいワードを追加するのは `length % epu == 0` のとき。  
+逆に `pop` / `resize` で減らす際も同様に末尾ワードを解放する。
+
+### バルク操作のアトミック性
+
+```rust
+pub fn extend<I>(&mut self, vals: I) -> Result<(), RadixArrayError>
+where I: IntoIterator<Item = i64>
+{
+    let orig = self.length;
+    for v in vals {
+        if let Err(e) = self.push(v) {
+            self.resize(orig); // ロールバック
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+```
+
+`IntArray::extend` と同じパターン。
+
+### 速度に関するトレードオフ
+
+| 操作 | ビット詰め（IntArray） | 基数方式（RadixArray） |
+|---|---|---|
+| get | シフト + マスク（〜3サイクル）| 除算2回 + 剰余（〜60サイクル）|
+| set | シフト + マスク + OR | 除算 + 乗算 + 加減算 |
+| メモリ（K=3）| 32 要素/u64 | 40 要素/u64（+25%）|
+
+CPU バウンドな処理では遅くなる。メモリバウンドな大規模データでは、キャッシュライン効率の向上により逆に速くなる可能性がある。
+
+## Serde
+
+`IntArray` と同様にフラットな整数列として直列化する。
+
+- Serialize: `[i64, ...]`（A を加算した実際の値）
+- Deserialize: 値列の min・max から A・B を自動設定する。**情報損失に注意**（下記）
+
+```
+serialize([−1, 0, 1]) → [-1, 0, 1]
+deserialize([-1, 0, 1]) → RadixArray { a: -1, b: 1, ... }
+```
+
+**空配列のデシリアライズ:**  
+min/max が求まらないため、`a=0, b=1`（K=2）をデフォルトとする。IntArray の空配列デシリアライズが bits=1 になるのと対応する。
+
+```
+deserialize([]) → RadixArray { a: 0, b: 1, length: 0 }
+```
+
+**Note:** シリアライズ時に A・B は保存されない。デシリアライズ後の範囲は元の範囲と異なる場合がある。
+
+```
+// 元の範囲 [-5, 5] だが、値が [0, 1] に収まっている場合
+serialize(RadixArray { a: -5, b: 5, vals: [0, 1, 0] }) → [0, 1, 0]
+deserialize([0, 1, 0]) → RadixArray { a: 0, b: 1 }  // a=-5, b=5 は失われる
+```
+
+また、全要素が同じ値の場合は min == max となり K=1 になるため、min を A、max+1 を B（K=2）として扱う。
+
+```
+deserialize([3, 3, 3]) → RadixArray { a: 3, b: 4 }  // K=2
+```
+
+## ファイル構成（案）
+
+現行の `intarray` クレートとは別クレートにする。`IntArrayError` は共通化せず、`RadixArrayError` を独立して定義する。
+
+```
+rarray/
+  Cargo.toml
+  src/
+    lib.rs       # RadixArray 本体
+    iter.rs      # RadixIter
+    tests.rs     # テスト
+  examples/
+    basic.rs
+```
+
+## テスト方針
+
+- `epu` の境界（要素インデックス 0、epu-1、epu、epu+1）
+- 末尾ワードの部分使用（length が epu の倍数でない場合）
+- 範囲外の値（TooLarge / TooSmall）
+- ロールバック（extend で途中エラー → 元のサイズに戻ること）
+- 各 K ごとに epu の計算が正しいことを確認
+- K が 2 の冪（K=2, 4, 8）でビット詰めと同等の epu になること
+- 負の範囲（A < 0 < B）
+- A = B は K=1（1 種類の値）→ `InvalidRange` として弾く
+
+## 将来の拡張（スコープ外）
+
+- `shape(a, b)` — 範囲を変えてコピー（値が収まらない場合エラー）
+- `AddAssign` / `SubAssign` — SIMD 的な一括加算（基数方式では非自明）
+- `fill_random` — 範囲内の乱数で埋める
+- `subarray` — 部分配列（ワード境界で高速パスを取るのは困難）

--- a/SPEC_ratio.md
+++ b/SPEC_ratio.md
@@ -1,0 +1,494 @@
+# RatioArray 仕様
+
+## 概要
+
+`RatioArray` は、任意精度有理数（`num_rational::Ratio<BigInt>`）を
+可変長符号（Elias gamma）でビット詰めし、ブロック単位で管理するパック配列である。
+
+分子と分母をそれぞれ Elias gamma で直列に符号化するため、
+小さい分母（特に分母=1の整数）を多く含む場合にメモリ効率が高くなる。
+
+`Ratio<BigInt>` は常に既約分数に正規化される（GCD で約分、分母は正）。
+`RatioArray` はこの正規化済みの値を受け取って格納し、取り出す。
+
+### 既存の型との位置づけ
+
+| 型 | 要素型 | 主な用途 |
+|---|---|---|
+| `IntArray` | `u64` | 符号なし整数（固定ビット幅） |
+| `RadixArray` | `i64` | 符号あり整数（固定範囲） |
+| `FloatArray` | `f64` | 浮動小数点（固定精度） |
+| `VarIntArray` | `BigInt` | 可変長整数 |
+| `RatioArray` | `Ratio<BigInt>` | 有理数（丸め誤差なし） |
+
+---
+
+## 符号化方式
+
+`Ratio<BigInt>` 値 `p/q`（`q ≥ 1`、既約）を以下の順でビット列に変換する：
+
+```
+[分子 p の符号化] [分母 q の符号化]
+```
+
+### 分子 p の符号化（VarIntArray と同一）
+
+符号あり `BigInt p` を非負の `BigUint z` に Zigzag 変換してから拡張 Elias gamma で符号化する。
+
+**Zigzag エンコーディング：**
+
+```
+p =  0  →  z = 0
+p >  0  →  z = 2 * p
+p <  0  →  z = 2 * |p| - 1
+```
+
+逆変換：
+
+```
+z が偶数  →  p = z / 2
+z が奇数  →  p = -(z + 1) / 2
+```
+
+**拡張 Elias gamma（BigUint z ≥ 0）：**
+
+1. `B = z.bits() as usize`（`BigUint::bits()` は `u64` を返す。z=0 のとき B=0）
+2. `B+1` を標準 Elias gamma で符号化（k=floor(log2(B+1))、"k個の0" + "1" + "B+1の下位kビット MSBファースト"）
+3. z の上位 B ビットを MSB ファーストで追記
+
+デコードは VarIntArray §Elias gamma のデコード手順 と同一。
+
+### 分母 q の符号化（標準 Elias gamma）
+
+`q` は常に `q ≥ 1` であるため、標準 Elias gamma をそのまま適用できる：
+
+**エンコード：**
+
+```
+k_bits = q.bits() as usize - 1   // = floor(log2(q))。q ≥ 1 なので常に定義される
+符号: k_bits 個の 0 + "1" + q の下位 k_bits ビット（MSB ファースト）
+合計: 2*k_bits + 1 ビット
+```
+
+**符号化例（分母）：**
+
+| q | k_bits | 符号 | ビット数 |
+|---|---|---|---|
+| 1 | 0 | "1" | 1 |
+| 2 | 1 | "010" | 3 |
+| 3 | 1 | "011" | 3 |
+| 4 | 2 | "00100" | 5 |
+| 7 | 2 | "00111" | 5 |
+| 10 | 3 | "0001010" | 7 |
+
+**デコード：**
+
+```
+1. 連続する 0 ビットの数を数える → k_bits
+2. "1" ビットを読んで捨てる
+3. k_bits ビットを読む → lower_bits
+4. q = 2^k_bits + lower_bits  （BigUint として構築）
+```
+
+### 符号化例（Ratio<BigInt> → ビット列）
+
+| 値 | p | q | 分子（ビット数） | 分母（ビット数） | 合計 |
+|---|---|---|---|---|---|
+| 0 | 0 | 1 | "1"（1 bit） | "1"（1 bit） | 2 bits |
+| 1 | 1 | 1 | "01110"（5 bits） | "1"（1 bit） | 6 bits |
+| -1 | -1 | 1 | "0101"（4 bits） | "1"（1 bit） | 5 bits |
+| 1/2 | 1 | 2 | "01110"（5 bits） | "010"（3 bits） | 8 bits |
+| -1/3 | -1 | 3 | "0101"（4 bits） | "011"（3 bits） | 7 bits |
+| 22/7 | 22 | 7 | "00111101100"（11 bits） | "00111"（5 bits） | 16 bits |
+
+22/7 の分子詳細：z=44=101100b、B=6、gamma(7): k=2、"00111"（5 bits）、data="101100"（6 bits）
+
+**整数値（q=1）は分母が常に "1"（1 bit）だけで済む**ため、VarIntArray と比べて 1 bit の追加のみ。
+
+### 1要素のデコード手順（ビット列 → Ratio<BigInt>）
+
+```
+1. 分子 p のデコード:
+   a. 拡張 Elias gamma のデコード:
+      i.  連続する 0 ビットの数を数える → k
+      ii. "1" ビットを読んで捨てる
+      iii. k ビットを読む → lower_bits
+      iv. B+1 = 2^k + lower_bits  → B = 2^k + lower_bits - 1
+      v.  B ビットを読む → z (BigUint, MSB ファースト)。B==0 のとき z=0
+   b. 逆 Zigzag: z が偶数 → p = z/2、z が奇数 → p = -(z+1)/2  (BigInt)
+
+2. 分母 q のデコード（標準 Elias gamma）:
+   a. 連続する 0 ビットの数を数える → k_bits
+   b. "1" ビットを読んで捨てる
+   c. k_bits ビットを読む → lower_bits
+   d. q = 2^k_bits + lower_bits  (BigUint)
+
+3. Ratio::new_raw(p, BigInt::from(q)) を返す
+   （格納時に正規化済みのため GCD 再計算不要）
+```
+
+### 複数要素のブロック内ビット列の例
+
+`[0, 1/2, -1]` を k=3 のブロックに格納した場合：
+
+```
+値    p   q  分子ビット列  分母ビット列  要素のビット列
+0     0   1  "1"           "1"           "11"           (2 bits)
+1/2   1   2  "01110"       "010"         "01110010"     (8 bits)
+-1   -1   1  "0101"        "1"           "01011"        (5 bits)
+
+連結: "11" | "01110010" | "01011"
+    = "110111001001011"  (15 bits)
+
+MSB ファーストでバイト列に格納（端数は 0 パディング）：
+  data[0] = 0b11011100  (b0〜b7)
+  data[1] = 0b10010110  (b8〜b14 + 1bit パディング)
+
+bit_len = 15, count = 3
+```
+
+### ビット列のバイト格納（VarIntArray と同一）
+
+```
+bit_pos p は data[p/8] のビット (7 - p%8) に対応する（MSB が先）
+
+書き込み: data[p/8] |= (1u8 << (7 - p%8))
+読み取り: bit = (data[p/8] >> (7 - p%8)) & 1
+
+末尾追記:
+  if bit_len % 8 == 0 { data.push(0u8) }
+  // 書き込み式で data[bit_len / 8] に書く
+  bit_len += 1
+```
+
+---
+
+## データ構造
+
+```
+RatioArray {
+    k:      usize,           // ブロックサイズ（構築時に指定）
+    blocks: Vec<BitBlock>,   // ブロックの配列
+    length: usize,           // 総要素数
+}
+
+BitBlock {
+    data:    Vec<u8>,        // エンコード済みビット列（MSB ファースト）
+    bit_len: usize,          // data 内の有効ビット数
+    count:   usize,          // このブロックの要素数
+}
+```
+
+**ブロックの不変条件：**
+- `blocks` が空でない場合、最後以外のすべてのブロックの `count == k`
+- 最後のブロックの `count` は 1 以上 k 以下
+- 空配列のとき `blocks` は空
+
+---
+
+## 構成パラメータの制約
+
+| 条件 | 理由 |
+|---|---|
+| `k >= 1` | ブロックサイズが 0 は無意味 |
+
+違反時: `Err(ArrayError::InvalidRange)`
+
+---
+
+## API
+
+### 構築
+
+```rust
+// 空の配列を作成
+RatioArray::new(k: usize) -> Result<Self, ArrayError>
+
+// Vec<Ratio<BigInt>> から構築
+RatioArray::new_with_vec(k: usize, vals: Vec<Ratio<BigInt>>) -> Result<Self, ArrayError>
+
+// イテレータから構築
+RatioArray::new_with_iter(k: usize, vals: impl Iterator<Item=Ratio<BigInt>>) -> Result<Self, ArrayError>
+```
+
+### 要素アクセス
+
+```rust
+get(i: usize) -> Result<Ratio<BigInt>, ArrayError>
+// blocks[i/k] の先頭から i%k+1 要素デコードして返す（部分デコード）
+// Err: OutOfBounds
+
+set(i: usize, v: Ratio<BigInt>) -> Result<(), ArrayError>
+// blocks[i/k] を全デコード → 差し替え → 再エンコード
+// Err: OutOfBounds
+```
+
+**set の詳細手順：**
+
+```
+1. i >= self.length なら Err(OutOfBounds)
+2. block_idx = i / k
+3. blocks[block_idx] の全要素をデコード → elems: Vec<Ratio<BigInt>>
+4. elems[i % k] = v
+5. blocks[block_idx] を空の BitBlock に置き換える:
+       blocks[block_idx] = BitBlock { data: vec![], bit_len: 0, count: 0 }
+6. elems の各要素を push の手順（step 2〜6）で blocks[block_idx] に書き戻す
+   （self.length は変化しないので注意。直接 blocks[block_idx] に書き込む）
+7. return Ok(())
+```
+
+値の変更でビット長が変わるため、再エンコード後は `blocks[block_idx].bit_len` と
+`blocks[block_idx].data` の長さが変わる場合がある。
+
+どちらも最悪計算量は O(K)。
+
+### スタック操作
+
+```rust
+push(v: Ratio<BigInt>) -> Result<usize, ArrayError>
+// 戻り値: 追加された要素のインデックス
+
+pop() -> Result<Ratio<BigInt>, ArrayError>
+// Err: Empty
+```
+
+**push の詳細手順：**
+
+```
+1. blocks が空、または最後のブロックの count == k の場合:
+       blocks.push(BitBlock { data: vec![], bit_len: 0, count: 0 })
+
+2. p = v.numer().clone()
+   q = BigUint::try_from(v.denom().clone()).unwrap()
+       // 分母は常に正なので unwrap は安全
+
+3. 分子 p を拡張 Elias gamma で符号化:
+   a. Zigzag: z = (p=0 → 0), (p>0 → 2*p), (p<0 → 2*|p|-1)  as BigUint
+   b. B = z.bits() as usize
+   c. k = floor(log2(B+1))
+      B+1 を標準 Elias gamma で符号化 → bits_to_write に追加
+      （k 個の 0 + "1" + B+1 の下位 k ビット MSBファースト）
+   d. z の上位 B ビットを MSBファーストで bits_to_write に追加
+
+4. 分母 q を標準 Elias gamma で符号化:
+   a. k_bits = q.bits() as usize - 1   // floor(log2(q))
+   b. k_bits 個の 0 を bits_to_write に追加
+   c. "1" を bits_to_write に追加
+   d. q の下位 k_bits ビットを MSBファーストで bits_to_write に追加
+
+5. bits_to_write の各ビットを末尾追記の手順で blocks.last_mut().data に書き込む
+
+6. blocks.last_mut().count += 1
+7. self.length += 1
+8. return Ok(self.length - 1)
+```
+
+**pop の詳細手順：**
+
+```
+1. blocks が空なら Err(Empty)
+2. 最後のブロックの全要素をデコード → elems: Vec<Ratio<BigInt>>
+3. ret = elems.pop()
+4. elems が空（count が 1 だった）なら blocks.pop() して self.length -= 1 → return Ok(ret)
+5. 最後のブロックを空の BitBlock に置き換える:
+       *blocks.last_mut() = BitBlock { data: vec![], bit_len: 0, count: 0 }
+6. elems の各要素を push の手順（step 2〜6）で書き戻す
+7. self.length -= 1
+8. return Ok(ret)
+```
+
+### 一括操作
+
+```rust
+extend(vals: impl IntoIterator<Item=Ratio<BigInt>>) -> Result<(), ArrayError>
+extend_array(other: &RatioArray) -> Result<(), ArrayError>
+// other の k と self の k が異なっても動作する。fast path なし。iter() → push() で実装。
+```
+
+`extend` / `extend_array` は atomic ではない（任意の `Ratio<BigInt>` を格納可能で値エラーが発生しないため、ロールバックは不要）。
+
+### 統計・イテレーション
+
+```rust
+iter(&self) -> RatioIter            // ExactSizeIterator<Item=Ratio<BigInt>>
+sum() -> Option<Ratio<BigInt>>      // None if empty
+min() -> Option<Ratio<BigInt>>      // None if empty
+max() -> Option<Ratio<BigInt>>      // None if empty
+average() -> Option<Ratio<BigInt>>  // None if empty（有理数として精度損失なし）
+len() -> usize
+is_empty() -> bool
+```
+
+`average` は `sum() / Ratio::from_integer(BigInt::from(self.length))` で計算する。
+浮動小数点と異なり精度損失なく正確な有理数値を返す。
+
+`Ratio<BigInt>` は `Ord` を実装するため `min` / `max` の比較は完全に正確。
+
+`sum` / `min` / `max` / `average` はすべて `iter()` を通じて逐次計算する（O(n)）。
+
+**RatioIter（VarIntArray の VarIntIter と同一の構造）：**
+
+```rust
+struct RatioIter<'a> {
+    arr: &'a RatioArray,
+    block_idx: usize,       // 現在のブロック番号
+    elem_in_block: usize,   // ブロック内の要素番号（0-origin）
+    bit_pos: usize,         // ブロック内の現在読み取りビット位置
+    remaining: usize,       // 残り要素数（ExactSizeIterator 用）
+}
+```
+
+`next()` の動作：
+1. `remaining == 0` なら `None`
+2. `elem_in_block == arr.blocks[block_idx].count` なら次ブロックへ
+   （`block_idx += 1, elem_in_block = 0, bit_pos = 0`）
+3. `bit_pos` から分子・分母を順にデコードし `bit_pos` を進める
+4. `elem_in_block += 1, remaining -= 1` して `Ratio::new_raw(p, BigInt::from(q))` を返す
+
+> `Ratio::new_raw` を使うのは、格納時に既約正規化済みであるため再計算不要だから。
+
+### メタデータ
+
+```rust
+block_size() -> usize     // = k
+block_count() -> usize    // = blocks.len()
+datasize() -> usize
+// size_of::<RatioArray>()
+// + size_of::<BitBlock>() * blocks.capacity()
+// + 各ブロックの data.capacity() の合計
+```
+
+---
+
+## エラー型
+
+| エラー | 発生箇所 |
+|---|---|
+| `OutOfBounds` | `get` / `set` のインデックス超過 |
+| `Empty` | `pop` を空配列に対して呼んだ |
+| `InvalidRange` | `new` で `k == 0` |
+
+---
+
+## 操作の計算量まとめ
+
+| 操作 | 時間計算量 | 備考 |
+|---|---|---|
+| `get(i)` | O(K) | ブロック内部分デコード |
+| `set(i, v)` | O(K) | ブロック全体の再符号化 |
+| `push(v)` | O(1) 均し | ブロック満杯時のみ新規作成 |
+| `pop()` | O(K) | ブロック全体の再符号化 |
+| `extend(n個)` | O(n) | push の繰り返し |
+| `iter()` 全走査 | O(n) | |
+| `sum` / `min` / `max` / `average` | O(n) | iter() 経由 |
+
+---
+
+## `PackedArrayCore` トレイトとの関係
+
+`Ratio<BigInt>` は `Copy` を実装しないため、`PackedArrayCore` は使用しない。
+`push` / `pop` / `extend` は `RatioArray` が独自に実装する。
+
+---
+
+## 表示 (Display)
+
+```
+[k=64][4]=0,1/2,-1/3,22/7
+  ^    ^
+  k    length
+```
+
+整数値（q=1）は `Ratio` の `Display` に準拠して "p" と表示する（"p/1" ではない）。
+
+---
+
+## シリアライズ (serde)
+
+- **Serialize**: 各要素を `Ratio` の `Display` でフォーマットした文字列配列として出力。
+  `q=1`（整数）のとき `"p"`、それ以外は `"p/q"` となる（num-rational の `Display` 実装による、実測確認済み）。
+- **Deserialize**: 文字列配列から `s.parse::<BigRational>()` で再構築する。
+  `num-rational` の `FromStr` は `"p/q"` 形式と整数 `"p"` 形式の両方を受け付ける。
+  `k` はデフォルト値（`k = 64`）を使用する。
+
+```json
+["0", "1/2", "-1/3", "22/7"]
+```
+
+> **注意**: デシリアライズで `k` は保存されない。元の `k` と異なる場合がある。
+> ただし `PartialEq` / `Eq` は要素値のみで比較する（`k` とブロック構造を無視）ため、
+> serde round-trip の前後で `==` は成立する。
+
+---
+
+## Cargo.toml への追加
+
+```toml
+[dependencies]
+num-rational = { version = "0.4", features = ["serde"] }
+# num-bigint は既存の依存として前提（num-rational 0.4 は num-bigint 0.4 を使用）
+```
+
+---
+
+## 設計上の決定事項
+
+| 項目 | 決定 | 理由 |
+|---|---|---|
+| 要素型 | `Ratio<BigInt>` | 任意精度、正規化保証、`num` エコシステムと統一 |
+| 分子符号化 | Zigzag + 拡張 Elias gamma | VarIntArray と同一、符号ありゼロを自然に扱える |
+| 分母符号化 | 標準 Elias gamma | `q ≥ 1` なので直接適用可。q=1（整数）が 1 bit で最小 |
+| average の戻り値 | `Ratio<BigInt>` | 有理数除算は精度損失なし（f64 より正確） |
+| デコード時の構築 | `Ratio::new_raw` | 格納時に正規化済みのため GCD 再計算不要 |
+| ブロック構造 | VarIntArray と同一 | 実装の再利用・一貫性 |
+| serde 表現 | "p/q" 文字列配列 | 任意精度を正確に表現 |
+| `PartialEq` / `Eq` | 要素値のみ比較（k・ブロック構造を無視） | serde round-trip 後も `==` が成立するようにするため |
+| デシリアライズ時の k | 64（`DEFAULT_K`） | k は外部表現に含まれないため固定値が必要 |
+| 共有コード | `src/bits.rs` に抽出 | `VarIntArray` と共通のビット I/O・Zigzag・Elias gamma ヘルパーを重複なく共有 |
+
+---
+
+## 実装上の注意点
+
+### 入力の正規化前提（`Ratio::new_raw` の危険性）
+
+`push` / `set` が受け取る `Ratio<BigInt>` は正規化済み（GCD=1、分母>0）を前提とする。
+`Ratio::new` で構築した場合は自動正規化されるが、`Ratio::new_raw` でバイパスすると以下の問題が起きる：
+
+| 不正な入力 | 挙動 |
+|---|---|
+| `Ratio::new_raw(p, BigInt::from(0))` | `write_denom` 内の `assert!` で panic（release/debug 両方） |
+| `Ratio::new_raw(p, BigInt::from(-1))` | `BigUint::try_from` が失敗し `unwrap()` で panic |
+
+`Ratio::new_raw` は "invariants を呼び出し側が保証する" 低レベル API である。
+`RatioArray` の公開 API に渡す場合は必ず `Ratio::new` を使うこと。
+
+### 内部不変条件
+
+`BitBlock` のビット列は常に `encode_into` → `decode_one` の組み合わせで読み書きされる。
+`read_bit` / `read_elias_gamma` / `read_denom` は不変条件が破れた場合（`data` が短すぎる等）に panic する。
+外部から `BitBlock` の `data` を直接書き換えることはできないため、通常の使い方では問題ない。
+
+### 32 ビット環境
+
+`BigUint::bits()` は `u64` を返すが、内部で `usize` にキャストする。
+32 ビット環境（`usize = u32`）では、2^32 ビット（約 500 MB の値）を超える分子・分母は
+切り詰められて誤ったエンコードになる。実用上は 64 ビット環境のみを想定している。
+
+### k の上限
+
+現行実装では `k == 0` のみ弾く（`Err(InvalidRange)`）。
+`k = usize::MAX` のような極端な値を設定すると全要素が 1 ブロックに収まり続け、
+`set` / `pop` が O(n) に劣化する。大きな k を使う際は注意。
+
+### 要素サイズの制限なし
+
+任意精度の `BigInt` を格納できるため、数十億ビットの値を push すると
+その場で数百 MB を消費する。デシリアライズ経由で外部 JSON を取り込む場合は
+特に注意（文字列長に上限を設けることを推奨）。
+
+---
+
+## 疑問点・未解決事項
+
+（現時点ではなし）

--- a/SPEC_varint.md
+++ b/SPEC_varint.md
@@ -1,0 +1,459 @@
+# VarIntArray 仕様
+
+## 概要
+
+`VarIntArray` は、任意精度整数（`num_bigint::BigInt`）を可変長符号（Elias gamma）で
+ビット詰めし、ブロック単位で管理するパック配列である。
+
+値ごとに必要最小限のビット数を使うため、小さい値が多いほど高いメモリ効率が得られる。
+ブロック単位の管理により、要素の書き換え（`set`）を O(K) に抑える。
+
+### 既存の型との位置づけ
+
+| 型 | 要素型 | ビット幅 | 主な用途 |
+|---|---|---|---|
+| `IntArray` | `u64` | 固定 (1〜64) | 最大値が既知の符号なし整数 |
+| `RadixArray` | `i64` | 固定（範囲 [A,B] で決まる） | 範囲が既知の符号あり整数 |
+| `FloatArray` | `f64` | 固定 (exp+man+1) | 浮動小数点 |
+| `VarIntArray` | `BigInt` | **可変** | 最大値が未知・任意精度 |
+
+---
+
+## 符号化方式
+
+### Step 1: Zigzag エンコーディング（符号 → 非負）
+
+符号あり `BigInt` を非負の `BigUint` に変換する：
+
+```
+n =  0  →  z = 0
+n >  0  →  z = 2 * n
+n <  0  →  z = 2 * |n| - 1
+```
+
+逆変換：
+
+```
+z が偶数  →  n = z / 2
+z が奇数  →  n = -(z + 1) / 2
+```
+
+### Step 2: BigUint の Elias gamma 符号化
+
+`BigUint z` を自己区切り型ビット列に変換する：
+
+1. `B = z.bits() as usize`（`BigUint::bits()` は `u64` を返す。z の最小表現ビット数で、z=0 のとき B=0）
+2. `B+1` を標準 Elias gamma で符号化（B=0 のとき "1" の 1 ビット）
+3. z の上位 B ビットをそのまま追記（MSB ファースト）
+
+**標準 Elias gamma（正整数 n ≥ 1）：**
+
+```
+k = floor(log2(n))
+符号: k 個の 0 + "1" + n の下位 k ビット
+合計: 2k+1 ビット
+```
+
+**符号化例（BigInt → ビット列）：**
+
+| BigInt n | Zigzag z | B | gamma(B+1) | データ | 合計 |
+|---|---|---|---|---|---|
+| 0 | 0 | 0 | "1" | （なし） | 1 bit |
+| -1 | 1 | 1 | "010" | "1" | 4 bits |
+| 1 | 2 | 2 | "011" | "10" | 5 bits |
+| -2 | 3 | 2 | "011" | "11" | 5 bits |
+| 2 | 4 | 3 | "00100" | "100" | 8 bits |
+| 127 | 254 | 8 | "0001001" | "11111110" | 15 bits |
+| 2^64 | 2^65 | 66 | 13 bits | 66 bits | 79 bits |
+| 2^1000 | 2^1001 | 1002 | 19 bits | 1002 bits | 1021 bits |
+
+**Elias gamma のデコード手順（1値分）：**
+
+```
+1. 連続する 0 ビットの数を数える → k
+   （"1" ビットが来るまで 1 ビットずつ読む）
+2. "1" ビットを読んで捨てる（区切り）
+3. k ビットを読む → lower_bits
+4. B+1 = 2^k + lower_bits  → B = 2^k + lower_bits - 1
+```
+
+例: ビット列 "0001001..." を読む場合
+- 0 が 3 個 → k=3
+- "1" を読んで捨てる
+- 次の 3 ビット "001" を読む → lower_bits=1
+- B+1 = 2^3 + 1 = 9 → B = 8
+
+**BigUint のデコード手順（1値分）：**
+
+```
+1. 上記 Elias gamma デコードで B を得る
+2. B == 0 の場合: z = 0（データビットなし）
+3. B > 0 の場合: 次の B ビットを MSB ファーストで読む → z
+```
+
+**BigInt のデコード手順（1値分）：**
+
+```
+1. 上記で z（BigUint）を得る
+2. 逆 Zigzag:
+   z が偶数 → n = z / 2
+   z が奇数 → n = -(z + 1) / 2
+```
+
+**自己区切り性（self-delimiting）：**
+
+Elias gamma 自体が自己区切り符号（先頭の連続する 0 の個数 k が長さを示す）であり、
+B+1 を読み終えた時点で「次に読むべきビット数 = B」が確定する。
+したがって、ブロック内のビット列を先頭から順に読むだけで、
+各要素の境界を外部インデックスなしに正確に検出できる。
+
+**複数要素のブロック内ビット列の例：**
+
+`[0, -1, 1, -2]` を k=4 のブロックに格納した場合：
+
+```
+要素  n    z   B  gamma(B+1)  データ  要素のビット列
+  0   0    0   0  "1"         ""      "1"       (1 bit)
+ -1  -1    1   1  "010"       "1"     "0101"    (4 bits)
+  1   1    2   2  "011"       "10"    "01110"   (5 bits)
+ -2  -2    3   2  "011"       "11"    "01111"   (5 bits)
+
+連結: "1" | "0101" | "01110" | "01111"
+    = "101010111001111"  (15 bits)
+
+MSB ファーストでバイト列に格納（端数は 0 パディング）：
+  b0〜b7  : 1,0,1,0,1,0,1,1 → data[0] = 0b10101011
+  b8〜b14 : 1,0,0,1,1,1,1   → data[1] = 0b10011110  (最下位 1bit はパディング)
+
+bit_len = 15, count = 4
+```
+
+### ビット列のバイト格納（MSB ファースト）
+
+```
+ビット列: [b0 b1 b2 b3 b4 b5 b6 b7 | b8 b9 ...]
+バイト:    [ data[0]                 | data[1] ...]
+
+bit_pos p は data[p/8] のビット (7 - p%8) に対応する（MSB が先）
+```
+
+書き込み（bit_pos の位置に 1 を立てる）：
+```
+byte_idx = bit_pos / 8
+bit_idx  = 7 - (bit_pos % 8)
+data[byte_idx] |= (1u8 << bit_idx)
+```
+
+読み取り（bit_pos の位置のビット値を得る）：
+```
+byte_idx = bit_pos / 8
+bit_idx  = 7 - (bit_pos % 8)
+bit = (data[byte_idx] >> bit_idx) & 1
+```
+
+新しいビットを末尾に追記するとき（`data` の拡張が必要な場合）：
+```
+if bit_len % 8 == 0 {
+    data.push(0u8)   // 新しいバイトを確保
+}
+// 上記の書き込み式で data[bit_len / 8] に書く
+bit_len += 1
+```
+
+---
+
+## データ構造
+
+```
+VarIntArray {
+    k:      usize,           // ブロックサイズ（構築時に指定）
+    blocks: Vec<BitBlock>,   // ブロックの配列
+    length: usize,           // 総要素数
+}
+
+BitBlock {
+    data:    Vec<u8>,        // Elias gamma ビット列（MSB ファースト）
+    bit_len: usize,          // data 内の有効ビット数
+    count:   usize,          // このブロックの要素数
+}
+```
+
+**ブロックの不変条件：**
+- `blocks` が空でない場合、最後以外のすべてのブロックの `count == k`
+- 最後のブロックの `count` は 1 以上 k 以下
+- 空配列のとき `blocks` は空
+
+---
+
+## 構成パラメータの制約
+
+| 条件 | 理由 |
+|---|---|
+| `k >= 1` | ブロックサイズが 0 は無意味 |
+
+違反時: `Err(ArrayError::InvalidRange)`
+
+### k の選択ガイド
+
+| k | get/set コスト | インデックスサイズ |
+|---|---|---|
+| 16 | 速い | やや多い |
+| 64 | 中程度（推奨） | 少ない |
+| 256 | 遅い | 非常に少ない |
+
+---
+
+## API
+
+### 構築
+
+```rust
+// 空の配列を作成
+VarIntArray::new(k: usize) -> Result<Self, ArrayError>
+
+// Vec<BigInt> から構築
+VarIntArray::new_with_vec(k: usize, vals: Vec<BigInt>) -> Result<Self, ArrayError>
+
+// イテレータから構築
+VarIntArray::new_with_iter(k: usize, vals: impl Iterator<Item=BigInt>) -> Result<Self, ArrayError>
+```
+
+### 要素アクセス
+
+```rust
+get(i: usize) -> Result<BigInt, ArrayError>
+// ブロック blocks[i/k] の先頭から i%k 要素デコードして返す
+// Err: OutOfBounds
+
+set(i: usize, v: BigInt) -> Result<(), ArrayError>
+// blocks[i/k] を全デコード → 差し替え → 再エンコード
+// Err: OutOfBounds
+```
+
+`get` はブロック先頭から対象要素まで**部分デコード**（最大 `i%k + 1` 要素）。全要素を復元する必要はない。
+`set` はブロックの**全要素をデコード**してから差し替え・再エンコードする。再エンコード後のブロックサイズは変わる場合がある（`bit_len` と `data` の長さを更新する）。
+どちらも最悪計算量は O(K)。
+
+### スタック操作
+
+```rust
+push(v: BigInt) -> Result<usize, ArrayError>
+// 最後のブロックに追記。満杯（count == k）なら新ブロック作成。
+// 戻り値: 追加された要素のインデックス
+// 任意の BigInt を格納可能なため値エラーは発生しない
+
+pop() -> Result<BigInt, ArrayError>
+// 最後のブロックを全デコード → 末尾を取り出し → 再エンコード
+// ブロックが空になったら blocks から削除
+// Err: Empty
+```
+
+**pop の詳細手順：**
+
+```
+1. blocks が空なら Err(Empty)
+2. 最後のブロック（blocks.last()）の全要素をデコード → elems: Vec<BigInt>
+3. ret = elems.pop() （末尾を取り出す）
+4. elems が空（count が 1 だった）なら blocks.pop() して self.length -= 1 → return Ok(ret)
+5. 最後のブロックを空の BitBlock に置き換える:
+       *blocks.last_mut() = BitBlock { data: vec![], bit_len: 0, count: 0 }
+6. elems の各要素を push の手順（step 2〜7）で書き戻す
+   （push を呼ぶと self.length が変化するため、直接 blocks.last_mut() に書き込む）
+7. self.length -= 1
+8. return Ok(ret)
+```
+
+**push の詳細手順：**
+
+```
+1. blocks が空、または最後のブロックの count == k の場合:
+       blocks.push(BitBlock { data: vec![], bit_len: 0, count: 0 })
+
+2. v を Zigzag エンコード → z (BigUint)
+3. B = z.bits() as usize   // num-bigint の bits() は u64 を返すので usize にキャスト
+4. B+1 を標準 Elias gamma で符号化 → bits_to_write: Vec<bool>
+       k = floor(log2(B+1))  ← B+1 >= 1 なので常に定義される（B=0 のとき k=0）
+       k 個の 0 ビット、"1" ビット、B+1 の下位 k ビット（MSB から順）
+5. z の上位 B ビットを MSB ファーストで bits_to_write に追加
+6. bits_to_write の各ビットを、上記「新しいビットを末尾に追記」の手順で
+   blocks.last_mut() の data に書き込む（bit_len を 1 ずつ進める）
+7. blocks.last_mut().count += 1
+8. self.length += 1
+9. return Ok(self.length - 1)
+```
+
+### 一括操作
+
+```rust
+extend(vals: impl IntoIterator<Item=BigInt>) -> Result<(), ArrayError>
+// 各要素を push する。値エラーは発生しない。
+
+extend_array(other: &VarIntArray) -> Result<(), ArrayError>
+// other の全要素を self に追加する。other の k と self の k が異なっても動作する。
+// fast path なし（ブロック境界が一致しないため）。iter() → push() で実装する。
+```
+
+`extend` / `extend_array` は atomic ではない（値エラーが発生しないためロールバック不要）。
+
+### 統計・イテレーション
+
+```rust
+iter(&self) -> VarIntIter       // ExactSizeIterator<Item=BigInt>; インデックス 0 から順に返す
+sum() -> Option<BigInt>         // None if empty
+min() -> Option<BigInt>         // None if empty
+max() -> Option<BigInt>         // None if empty
+average() -> Option<f64>        // None if empty; BigInt → f64 変換で精度が落ちる場合がある
+len() -> usize
+is_empty() -> bool
+```
+
+`VarIntIter` はビット位置を直接保持し、`next()` のたびに 1 要素をデコードして返す：
+
+```rust
+struct VarIntIter<'a> {
+    arr: &'a VarIntArray,
+    block_idx: usize,    // 現在のブロック番号
+    elem_in_block: usize, // ブロック内の要素番号（0-origin）
+    bit_pos: usize,      // ブロック内の現在読み取りビット位置
+    remaining: usize,    // 残り要素数（ExactSizeIterator 用）
+}
+```
+
+`next()` の動作：
+1. `remaining == 0` なら `None` を返す
+2. `elem_in_block == arr.blocks[block_idx].count` なら次のブロックへ進む
+   （`block_idx += 1`, `elem_in_block = 0`, `bit_pos = 0`）
+3. 現在ブロックの `bit_pos` から 1 要素デコード、`bit_pos` を進める
+4. `elem_in_block += 1`, `remaining -= 1` して値を返す
+
+`sum` / `min` / `max` はすべて `iter()` を通じて逐次計算する（O(n)）。
+`average` は `sum()` を `num_traits::ToPrimitive::to_f64()` で `f64` に変換してから要素数（`usize as f64`）で除算する。
+`BigInt` が `f64` の精度（53 bit 仮数）を超える場合は精度損失が生じる。`to_f64()` は `num-traits = "0.2"` の `ToPrimitive` トレイトが提供する。
+sum の絶対値が `f64::MAX`（約 1.8×10^308）を超える場合、`to_f64()` は `±Infinity` を返すため `average()` も `±Infinity` になる。`None` にはならない。
+
+### メタデータ
+
+```rust
+block_size() -> usize          // = k（構築時に指定した値）
+block_count() -> usize         // = blocks.len()
+datasize() -> usize
+// size_of::<VarIntArray>()
+// + size_of::<BitBlock>() * blocks.capacity()   // Vec<BitBlock> の確保済み領域
+// + 各ブロックの data.capacity()                // 各 Vec<u8> の確保済みバイト数の合計
+```
+
+---
+
+## エラー型
+
+`VarIntArray` が返す `ArrayError` の種類：
+
+| エラー | 発生箇所 |
+|---|---|
+| `OutOfBounds` | `get` / `set` のインデックス超過 |
+| `Empty` | `pop` を空配列に対して呼んだ |
+| `InvalidRange` | `new` で `k == 0` |
+
+`TooLarge` / `TooSmall` は発生しない（任意の `BigInt` を格納可能）。
+
+---
+
+## 操作の計算量まとめ
+
+| 操作 | 時間計算量 | 備考 |
+|---|---|---|
+| `get(i)` | O(K) | ブロック内スキャン |
+| `set(i, v)` | O(K) | ブロック全体の再符号化 |
+| `push(v)` | O(1) 均し | ブロック満杯時のみ新規作成 |
+| `pop()` | O(K) | ブロック全体の再符号化 |
+| `extend(n個)` | O(n) | push の繰り返し |
+| `iter()` 全走査 | O(n) | ブロックを順に展開 |
+
+---
+
+## `PackedArrayCore` トレイトとの関係
+
+`BigInt` は `Copy` を実装しないため、`PackedArrayCore` トレイト（`type Item: Copy` が必要）は使用しない。
+`push` / `pop` / `extend` は `VarIntArray` が独自に実装する。
+
+---
+
+## 表示 (Display)
+
+```
+[k=64][5]=0,-1,1,-2,1000000000000000000000
+  ^    ^
+  k    length
+```
+
+大きな値は十進数文字列で表示する。
+
+---
+
+## シリアライズ (serde)
+
+- **Serialize**: 要素を十進文字列のフラット配列として出力（JSON の数値型では任意精度 BigInt を表現できないため）。
+- **Deserialize**: 文字列配列から再構築。`k` は保存されないため、デシリアライズ時はデフォルト値（`k = 64`）を使用する。
+
+```json
+["0", "-1", "1", "-2", "1000000000000000000000"]
+```
+
+> **注意**: デシリアライズで `k` は保存されない。元の `k` と異なる場合がある。
+> ただし `PartialEq` は要素値のみで比較する（`k` とブロック構造を無視）ため、
+> serde round-trip の前後で `==` は成立する。
+
+---
+
+## Cargo.toml への追加
+
+```toml
+[dependencies]
+num-bigint = { version = "0.4", features = ["serde"] }
+num-traits = "0.2"
+```
+
+---
+
+## 設計上の決定事項
+
+| 項目 | 決定 | 理由 |
+|---|---|---|
+| 要素型 | `num_bigint::BigInt` | 任意精度、符号あり、Rust 標準的 |
+| 符号処理 | Zigzag エンコーディング | 負の値を非負に変換してから Elias gamma を適用 |
+| 長さ符号化 | Elias gamma (B+1) | 0 も自然に扱える、オーバーヘッドが O(log B) |
+| ビット順序 | MSB ファースト | Elias gamma のゼロ列を素直に表現できる |
+| 可変性 | Full（set 可能） | O(K) でブロック単位の再符号化 |
+| ブロックサイズ k | 構築時に指定 | メモリと速度のトレードオフをユーザーが制御 |
+| `PackedArrayCore` | 使用しない | `BigInt` が `Copy` でないため |
+| serde 表現 | 十進文字列配列 | 任意精度を JSON で正確に表現 |
+| `PartialEq` | 要素値のみ比較（k・ブロック構造を無視） | serde round-trip 後も `==` が成立するようにするため |
+| デシリアライズ時の k | 64（`DEFAULT_K`） | k は外部表現に含まれないため固定値が必要 |
+
+---
+
+## 実装上の注意点
+
+### 内部不変条件
+
+`BitBlock` のビット列は常に `encode_into` → `read_elias_gamma` の組み合わせで読み書きされる。
+`read_bit` / `read_elias_gamma` は不変条件が破れた場合（`data` が短すぎる等）に panic する。
+外部から `BitBlock` の `data` を直接書き換えることはできないため、通常の使い方では問題ない。
+
+### 32 ビット環境
+
+`BigUint::bits()` は `u64` を返すが、内部で `usize` にキャストする。
+32 ビット環境（`usize = u32`）では、2^32 ビット（約 500 MB の整数）を超える `BigUint` は
+切り詰められて誤ったエンコードになる。実用上は 64 ビット環境のみを想定している。
+
+### k の上限
+
+現行実装では `k == 0` のみ弾く（`Err(InvalidRange)`）。
+`k = usize::MAX` のような極端な値を設定すると全要素が 1 ブロックに収まり続け、
+`set` / `pop` が O(n) に劣化する。大きな k を使う際は注意。
+
+---
+
+## 疑問点・未解決事項
+
+（現時点ではなし）


### PR DESCRIPTION
- Add RatioArray to README (quick start, API, serialization)
- Add VarIntArray and FloatArray sections to README
- Add SPEC files for all 5 array types
- Bump version to 0.4.0